### PR TITLE
chore: add Codex MCP config

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -3,3 +3,15 @@ command = "uv"
 args    = ["run", "lymcp"]
 cwd     = "."
 enabled = true
+
+[mcp_servers.lymcp.tools.get_stat]
+approval_mode = "approve"
+
+[mcp_servers.lymcp.tools.list_legislators]
+approval_mode = "approve"
+
+[mcp_servers.lymcp.tools.list_bills]
+approval_mode = "approve"
+
+[mcp_servers.lymcp.tools.get_bill]
+approval_mode = "approve"

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,5 @@
+[mcp_servers.lymcp]
+command = "uv"
+args    = ["run", "lymcp"]
+cwd     = "."
+enabled = true

--- a/README.md
+++ b/README.md
@@ -178,6 +178,12 @@ cd ly-mcp
 uv sync
 ```
 
+### Using Codex CLI
+
+This repository includes `.codex/config.toml` for local Codex CLI development.
+When you start Codex CLI from the repository root, it can use the configured
+`lymcp` MCP server via `uv run lymcp`.
+
 ### Running the MCP Inspector
 
 ```bash


### PR DESCRIPTION
## Summary
- add repo-local Codex MCP server config for lymcp
- run the server with uv from the repository root

## Validation
- python -c "import pathlib, tomllib; tomllib.loads(pathlib.Path('.codex/config.toml').read_text())"