### PR TITLE
docs: add lymcp improvement plans

### DIFF
--- a/docs/plans/2026-05-14_api-coverage-and-tool-schema-plan.md
+++ b/docs/plans/2026-05-14_api-coverage-and-tool-schema-plan.md
@@ -1,0 +1,57 @@
+## Goal
+
+Bring the MCP tool surface into alignment with `swagger.yaml` and make query parameters easier to discover and use. Success means every Legislative Yuan API v2 endpoint in `swagger.yaml` has an intentional MCP representation, and supported filters are either exposed as tool parameters or explicitly documented as intentionally raw.
+
+## Context
+
+The current server exposes 36 MCP tools, while `swagger.yaml` lists 39 endpoints. The missing endpoint group is the top-level Law Version API:
+
+- `/law_versions`
+- `/law_versions/{id}`
+- `/law_versions/{id}/contents`
+
+Live `list_bills` responses also report `supported_filter_fields` that are not all represented in the MCP tool schema, such as `提案單位/提案委員`.
+
+## Architecture
+
+The current code has a direct two-layer wrapper:
+
+- `src/lymcp/api.py` defines Pydantic request models and API calls.
+- `src/lymcp/server.py` exposes FastMCP tools that construct request models and JSON-dump responses.
+- `src/lymcp/translate.py` maps English internal parameter names to Legislative Yuan API query-field names.
+
+This plan keeps that architecture and adds only the missing request classes, translation keys, server tools, and tests.
+
+## Non-Goals
+
+- Do not redesign all tools or replace the current wrapper architecture.
+- Do not remove existing parameter names such as `cosigner`; add compatible aliases only if needed.
+- Do not add generated OpenAPI client code in this phase.
+
+## Unknowns
+
+- Whether `/law_versions/{id}/contents` uses the same content ID shape as `law_contents`; resolve by running one live query from a known version ID before implementing tests.
+- Whether all `supported_filter_fields` should become first-class MCP parameters or stay accessible through a generic raw filter mechanism; resolve by auditing repeated fields across endpoint categories.
+
+## Plan
+
+- [ ] Build an endpoint-to-tool audit table from `swagger.yaml` and current `@mcp.tool()` definitions to identify missing and intentionally unsupported endpoints; verify with a checked-in note or test fixture listing all endpoint paths and tool names.
+- [ ] Add translation keys for Law Version filters and IDs in `src/lymcp/translate.py` to support `/law_versions` and `/law_versions/{id}/contents`; verify with unit tests asserting serialized query parameter names.
+- [ ] Add `ListLawVersionsRequest`, `GetLawVersionRequest`, and `GetLawVersionContentsRequest` in `src/lymcp/api.py` to call `/law_versions`, `/law_versions/{id}`, and `/law_versions/{id}/contents`; verify with monkeypatched API tests that assert URL and params.
+- [ ] Add `list_law_versions`, `get_law_version`, and `get_law_version_contents` tools in `src/lymcp/server.py` with clear Traditional Chinese parameter descriptions; verify with MCP `list_tools` tests and fixture-backed tool call tests.
+- [ ] Compare API `supported_filter_fields` against tool parameters for bills, laws, law versions, meetings, IVODs, and legislators; verify with an audit output that marks each field as `first-class parameter`, `output_fields only`, or `deferred`.
+- [ ] Add first-class parameters for high-value missing filters, starting with bill `提案單位/提案委員` if confirmed by `swagger.yaml` or live responses; verify with request serialization tests and one live smoke query.
+- [ ] Update `README.md` feature lists and examples to include Law Version tools only after the tools and tests exist; verify by matching README tool names against MCP `list_tools`.
+
+## Risks
+
+- Some query fields appear only in live `supported_filter_fields` but not in `swagger.yaml`, so adding them blindly could create unstable behavior.
+- Law version IDs include colons and Chinese action names, so URL encoding and examples must be tested.
+- Adding many first-class parameters can make tool schemas noisy; prioritize high-value filters first.
+
+## Completion Checklist
+
+- [ ] All 39 `swagger.yaml` endpoints are intentionally represented or documented as out of scope, verified by the endpoint-to-tool audit.
+- [ ] The three Law Version MCP tools are available in `list_tools`, verified by a server test.
+- [ ] Law Version request classes serialize URLs and params correctly, verified by monkeypatched API unit tests.
+- [ ] README feature counts and tool lists match the actual server, verified by manual review against `rg "@mcp.tool" src/lymcp/server.py`.

--- a/docs/plans/2026-05-14_discovery-prompts-and-query-semantics-plan.md
+++ b/docs/plans/2026-05-14_discovery-prompts-and-query-semantics-plan.md
@@ -1,0 +1,49 @@
+## Goal
+
+Improve MCP usability for common Legislative Yuan research tasks by adding discoverable guidance, reusable prompts/resources, and bounded query semantics for "latest", "scheduled", "occurred", law histories, and legislator activity. Success means users can ask common questions with less trial-and-error and get results whose date semantics are explicit.
+
+## Context
+
+Live MCP checks showed that default sorted results can include future scheduled bills and meetings. On 2026-05-14, `list_bills(term=11)` returned bills with proposal dates after the current date, and `list_meets(term=11)` returned meetings scheduled for future dates. This is valid source data, but natural-language prompts like "最近一次院會" need a clear distinction between latest known record, latest occurred meeting, and next scheduled meeting.
+
+## Architecture
+
+Keep raw list/detail tools available. Add guidance and optional helper surfaces on top:
+
+- MCP prompts for common workflows.
+- MCP resources or documentation snippets for filter fields and ID usage.
+- Optional helper tools only if prompts/resources are insufficient.
+
+## Non-Goals
+
+- Do not build a separate analytics engine in this phase.
+- Do not guarantee legal interpretation or official status beyond the source API data.
+- Do not remove access to future scheduled records.
+
+## Unknowns
+
+- Whether FastMCP prompt/resource support in the pinned `mcp` version is sufficient for this repository's packaging style; resolve by checking local docs or a minimal prototype before implementation.
+- Whether users prefer helper tools such as `get_latest_meet` or prompt-only guidance; resolve after a first prompt/resource prototype.
+
+## Plan
+
+- [ ] Identify the top 5 user workflows from README examples and live research findings: latest plenary meeting bills, law amendment history, legislator proposal record, legislator interpellations, and committee meeting lookup; verify by mapping each workflow to existing tools and required IDs.
+- [ ] Document date semantics for `latest known`, `latest occurred`, and `next scheduled` queries, including the current-date comparison rule; verify with examples using fixed dates in tests or docs.
+- [ ] Add MCP prompts for the top workflows if supported by the current FastMCP version; verify by listing prompts through an MCP client or an in-repo prompt registration test.
+- [ ] Add MCP resources or a compact reference document for supported filter fields, ID fields, and example `output_fields`; verify by matching it against live response metadata such as `supported_filter_fields`.
+- [ ] Add representative README examples that avoid ambiguous "latest" wording or explicitly say whether scheduled records count; verify with live smoke runs through the configured MCP server.
+- [ ] Evaluate whether helper tools are needed for common date-bounded queries, such as latest occurred meeting before `today`; verify by comparing prompt-only usability against one implemented helper prototype or documented decision.
+- [ ] Add smoke-test prompts for the documented workflows using stable low-volume queries and record expected output shape; verify with a manual MCP smoke checklist or fixture-backed tests where possible.
+
+## Risks
+
+- Prompts/resources may be supported differently across MCP clients, so README examples remain important.
+- Date semantics can be sensitive to timezone; use Asia/Taipei dates when comparing Legislative Yuan records.
+- Helper tools can duplicate API features and increase maintenance cost; prefer prompts/resources until a concrete repeated failure justifies a helper.
+
+## Completion Checklist
+
+- [ ] Common workflows are documented as executable MCP prompts or README examples, verified by a reviewer running at least two examples.
+- [ ] "Latest" query semantics distinguish occurred and scheduled records, verified by docs or tests using fixed dates.
+- [ ] Filter and ID discovery is available without reading raw code, verified by MCP resources or README/developer docs.
+- [ ] Any helper tools added for date-bounded queries have tests and clear non-overlap with raw list tools.

--- a/docs/plans/2026-05-14_ly-mcp-improvement-roadmap-plan.md
+++ b/docs/plans/2026-05-14_ly-mcp-improvement-roadmap-plan.md
@@ -1,0 +1,40 @@
+## Goal
+
+Define the improvement roadmap for the current `lymcp` MCP server gaps found through repository review, OpenAPI comparison, and live MCP tool usage. Success means every identified gap is assigned to an executable plan with clear verification evidence.
+
+## Context
+
+The current server wraps the Legislative Yuan API v2 as MCP tools. Review found broad endpoint coverage, but also missing Law Version tools, weak contract testing, plain-string error handling, incomplete tool discoverability, no reusable MCP prompts/resources, and ambiguity around "latest" queries that include future scheduled records.
+
+## Non-Goals
+
+- Do not implement the fixes in this planning step.
+- Do not archive the existing `manual-live-and-mock-tests` plan automatically.
+- Do not introduce new runtime dependencies unless a downstream implementation plan proves they are needed.
+
+## Assumptions
+
+- `swagger.yaml` remains the local source of truth for supported API endpoints and query parameters.
+- The MCP server can keep returning text content when needed, but response and error semantics should become easier for clients and tests to validate.
+- Improvements can be split across focused PRs without requiring a large rewrite of the server.
+
+## Plan
+
+- [ ] Complete the API coverage work described in `docs/plans/2026-05-14_api-coverage-and-tool-schema-plan.md` to align MCP tools with `swagger.yaml`; verify with an endpoint-to-tool audit and MCP `list_tools` coverage.
+- [ ] Complete the test-contract work described in `docs/plans/2026-05-14_test-contract-and-ci-verification-plan.md` to make default tests deterministic and meaningful; verify with `just test`, `just lint`, and `just type`.
+- [ ] Complete the structured error and response work described in `docs/plans/2026-05-14_structured-errors-and-responses-plan.md` to make failures and result payloads machine-checkable; verify with unit tests for HTTP errors, JSON parse errors, and successful MCP tool output.
+- [ ] Complete the discovery and query semantics work described in `docs/plans/2026-05-14_discovery-prompts-and-query-semantics-plan.md` to improve common natural-language tasks such as latest meetings, law histories, and legislator activity lookups; verify with documented MCP prompts/resources and representative live smoke checks.
+- [ ] Update `README.md` after the implementation plans land so feature lists, test commands, and example prompts match actual behavior; verify by reviewing README sections against current `list_tools`, `justfile`, and pytest marker behavior.
+
+## Risks
+
+- The live Legislative Yuan API can return future schedule records, changing what "latest" means depending on user intent.
+- Tool schema changes can break existing users if parameter names are renamed instead of added compatibly.
+- Large raw JSON responses can remain token-heavy even after structured errors are improved.
+
+## Completion Checklist
+
+- [ ] Every gap from the research pass is represented by one linked plan, verified by comparing this roadmap against the issue list in the final research summary.
+- [ ] The roadmap remains bounded to planning work, verified by no production code changes in this PR or commit.
+- [ ] Each linked plan has `Goal`, `Plan`, and `Completion Checklist` sections with executable verification methods.
+- [ ] The user accepts the plan split or requests a different grouping, verified by explicit user acceptance or a follow-up edit request.

--- a/docs/plans/2026-05-14_structured-errors-and-responses-plan.md
+++ b/docs/plans/2026-05-14_structured-errors-and-responses-plan.md
@@ -1,0 +1,53 @@
+## Goal
+
+Improve response and error semantics so MCP clients and tests can distinguish successful data, empty results, invalid parameters, upstream HTTP failures, timeouts, and non-JSON responses. Success means tool failures are returned in a consistent, machine-checkable shape instead of arbitrary plain strings.
+
+## Context
+
+The current API helper calls `resp.raise_for_status()` and `resp.json()` directly. Server tools catch all exceptions and return strings like `Failed to list bills, got: ...`. This keeps the MCP server from crashing, but it makes errors hard for clients, tests, and users to interpret.
+
+## Architecture
+
+Keep `httpx` and the current request model layer. Introduce a small local response/error helper rather than a new dependency:
+
+- API layer normalizes upstream HTTP and JSON failures.
+- Server layer serializes a consistent success or error envelope.
+- Tests assert the envelope and error categories.
+
+## Non-Goals
+
+- Do not redesign the transport or replace FastMCP.
+- Do not hide the original Legislative Yuan API payload on successful calls.
+- Do not invent domain-specific summaries for every endpoint in this phase.
+
+## Assumptions
+
+- Returning JSON text content is acceptable for MCP compatibility, as long as the JSON shape is consistent.
+- Existing users can tolerate additional metadata fields if the original payload remains present.
+
+## Plan
+
+- [ ] Define a minimal response contract for tool output, for example `{ "ok": true, "data": ... }` and `{ "ok": false, "error": { "type": "...", "message": "...", "status_code": ... } }`; verify by documenting the contract in a short developer note or README testing section.
+- [ ] Add local exception classes or result helpers in `src/lymcp/api.py` for HTTP status errors, timeout/network errors, and JSON parse errors; verify with unit tests using monkeypatched `httpx.AsyncClient`.
+- [ ] Update server tool wrappers to serialize successful responses and structured errors consistently; verify with representative MCP tool tests for success and failure.
+- [ ] Preserve enough upstream detail for debugging, including endpoint URL path, status code, and response excerpt when safe; verify with tests that assert no traceback-only messages leak to the user.
+- [ ] Add tests for invalid bill ID, invalid law version ID, timeout, and non-JSON upstream response; verify with deterministic tests that do not call the live API.
+- [ ] Update README or developer docs to explain how MCP clients should interpret `ok`, `data`, and `error`; verify by matching docs to tests.
+
+## Risks
+
+- Changing the success envelope may be a breaking change for clients that expect the raw API object at the top level.
+- Including upstream response excerpts can leak noisy or overly large data; cap excerpts and avoid full HTML bodies.
+- Too much abstraction in error handling could make this small wrapper harder to read; keep helper APIs minimal.
+
+## Rollback / Recovery
+
+- If the success envelope is too disruptive, keep raw successful payloads unchanged and apply the structured envelope only to errors.
+- If downstream clients rely on exact text errors, release the change with a minor-version note and examples.
+
+## Completion Checklist
+
+- [ ] MCP tool errors are consistently machine-checkable, verified by tests for HTTP 404, timeout, and non-JSON responses.
+- [ ] Successful responses remain usable by existing clients or have documented migration notes, verified by README examples and tests.
+- [ ] Error messages include actionable endpoint/status context without raw tracebacks, verified by failure-path tests.
+- [ ] Quality gates pass after the change, verified by `just lint`, `just type`, and `just test`.

--- a/docs/plans/2026-05-14_test-contract-and-ci-verification-plan.md
+++ b/docs/plans/2026-05-14_test-contract-and-ci-verification-plan.md
@@ -1,0 +1,41 @@
+## Goal
+
+Make test and CI behavior match the documented offline/live split, and strengthen MCP contract tests so broken tools fail deterministically. Success means default validation does not require network access, live tests remain explicitly runnable, and tests assert JSON structure, request serialization, and error semantics instead of only checking for strings.
+
+## Context
+
+An existing completed plan, `docs/plans/2026-05-14_manual-live-and-mock-tests-plan.md`, already describes a live/mock test migration. The current repository still needs a follow-up verification pass because the research review found mismatch risks between README claims, `justfile`, pytest marker behavior, and tests that assert only `isinstance(response_text, str)`.
+
+## Non-Goals
+
+- Do not delete live tests.
+- Do not require live Legislative Yuan API access in default CI.
+- Do not broaden test fixtures to every endpoint before the first contract-hardening pass.
+
+## Unknowns
+
+- Whether the existing completed test plan is fully reflected in the current branch state; resolve by checking pytest collection, fixture files, and CI workflow files before changing tests.
+
+## Plan
+
+- [ ] Audit current test files, `pyproject.toml`, `justfile`, README testing docs, and CI workflows to verify the actual offline/live split; verify with `uv run pytest --collect-only tests` and `uv run pytest -m live --collect-only tests`.
+- [ ] If default pytest still collects live tests, add or repair marker filtering so live tests are skipped by default; verify with `just test` running without network access.
+- [ ] Replace MCP tests that only assert `TextContent` and `str` with assertions that parse JSON and validate top-level keys such as `total`, `page`, `limit`, result collection keys, and `supported_filter_fields`; verify with `uv run pytest tests/test_server*.py`.
+- [ ] Add request serialization tests for representative filters across bills, meetings, laws, law versions, IVODs, and legislators; verify by monkeypatching `make_api_request` and asserting URL plus params.
+- [ ] Add error-path tests for invalid IDs, HTTP 404, timeout, and non-JSON responses after structured error handling is implemented; verify with deterministic unit tests that do not call the live API.
+- [ ] Ensure `just test`, `just test-live`, README testing instructions, and CI workflow commands describe the same behavior; verify by reviewing all four places in one commit.
+- [ ] Run the final quality gates: `just lint`, `just type`, `just test`, and one explicit `just test-live` before release or PR merge; verify by recording command output in the PR or final implementation summary.
+
+## Risks
+
+- Live API shape changes can make fixture refresh necessary even when production code is correct.
+- Subprocess MCP tests are harder to isolate than API class tests; in-process server tests may be needed for deterministic coverage.
+- Tests that assert too much of the live payload can become brittle; focus on stable contracts and representative fields.
+
+## Completion Checklist
+
+- [ ] Default test execution is offline, verified by `just test` passing with live tests skipped and no network dependency.
+- [ ] Live tests remain available, verified by `just test-live` or `uv run pytest -m live tests`.
+- [ ] MCP server tests validate parsed JSON shape instead of only string type, verified by updated assertions in `tests/test_server*.py`.
+- [ ] Request classes have serialization coverage for high-value filters, verified by unit tests that assert URLs and params.
+- [ ] README, `justfile`, pytest config, and CI workflow agree on test commands, verified by manual review and passing commands.


### PR DESCRIPTION
## Summary
- add a roadmap for the MCP improvement work
- split follow-up work into API coverage, test contracts, structured errors, and discovery/query semantics plans

## Testing
- not run; docs-only planning change