### PR TITLE
docs(plans): close out completed plans

### DIFF
--- a/docs/plans/2026-05-14_api-coverage-and-tool-schema-plan.md
+++ b/docs/plans/2026-05-14_api-coverage-and-tool-schema-plan.md
@@ -2,19 +2,24 @@
 
 Bring the MCP tool surface into alignment with `swagger.yaml` and make query parameters easier to discover and use. Success means every Legislative Yuan API v2 endpoint in `swagger.yaml` has an intentional MCP representation, and supported filters are either exposed as tool parameters or explicitly documented as intentionally raw.
 
+## Status
+
+Completed. The server now exposes 39 MCP tools for the 39 endpoints listed in
+`swagger.yaml`, including the top-level Law Version API.
+
 ## Context
 
-The current server exposes 36 MCP tools, while `swagger.yaml` lists 39 endpoints. The missing endpoint group is the top-level Law Version API:
+At planning time, the server exposed 36 MCP tools while `swagger.yaml` listed 39 endpoints. The missing endpoint group was the top-level Law Version API:
 
 - `/law_versions`
 - `/law_versions/{id}`
 - `/law_versions/{id}/contents`
 
-Live `list_bills` responses also report `supported_filter_fields` that are not all represented in the MCP tool schema, such as `提案單位/提案委員`.
+Live `list_bills` responses also reported `supported_filter_fields` that were not all represented in the MCP tool schema, such as `提案單位/提案委員`.
 
 ## Architecture
 
-The current code has a direct two-layer wrapper:
+The code keeps a direct two-layer wrapper:
 
 - `src/lymcp/api.py` defines Pydantic request models and API calls.
 - `src/lymcp/server.py` exposes FastMCP tools that construct request models and JSON-dump responses.

--- a/docs/plans/2026-05-14_discovery-prompts-and-query-semantics-plan.md
+++ b/docs/plans/2026-05-14_discovery-prompts-and-query-semantics-plan.md
@@ -2,6 +2,12 @@
 
 Improve MCP usability for common Legislative Yuan research tasks by adding discoverable guidance, reusable prompts/resources, and bounded query semantics for "latest", "scheduled", "occurred", law histories, and legislator activity. Success means users can ask common questions with less trial-and-error and get results whose date semantics are explicit.
 
+## Status
+
+Completed. The server now exposes workflow prompts plus `lymcp://query-semantics`
+and `lymcp://workflow-reference` resources for date semantics and tool
+selection guidance.
+
 ## Context
 
 Live MCP checks showed that default sorted results can include future scheduled bills and meetings. On 2026-05-14, `list_bills(term=11)` returned bills with proposal dates after the current date, and `list_meets(term=11)` returned meetings scheduled for future dates. This is valid source data, but natural-language prompts like "最近一次院會" need a clear distinction between latest known record, latest occurred meeting, and next scheduled meeting.

--- a/docs/plans/2026-05-14_ly-mcp-improvement-roadmap-plan.md
+++ b/docs/plans/2026-05-14_ly-mcp-improvement-roadmap-plan.md
@@ -2,12 +2,16 @@
 
 Define the improvement roadmap for the current `lymcp` MCP server gaps found through repository review, OpenAPI comparison, and live MCP tool usage. Success means every identified gap is assigned to an executable plan with clear verification evidence.
 
+## Status
+
+Completed. All linked implementation plans have landed on `main`; this roadmap
+is retained as the closeout record for the improvement pass.
+
 ## Context
 
-The current server wraps the Legislative Yuan API v2 as MCP tools. Review found broad endpoint coverage, but also missing Law Version tools, weak contract testing, plain-string error handling, incomplete tool discoverability, no reusable MCP prompts/resources, and ambiguity around "latest" queries that include future scheduled records.
+At planning time, the server wrapped the Legislative Yuan API v2 as MCP tools with broad endpoint coverage, but review found missing Law Version tools, weak contract testing, plain-string error handling, incomplete tool discoverability, no reusable MCP prompts/resources, and ambiguity around "latest" queries that include future scheduled records.
 
-As of the `roadmap-completion` follow-up, all linked implementation plans have
-landed on `main` and this roadmap is being updated as a status record.
+The `roadmap-completion` follow-up marked the linked implementation plans done.
 
 ## Non-Goals
 

--- a/docs/plans/2026-05-14_manual-live-and-mock-tests-plan.md
+++ b/docs/plans/2026-05-14_manual-live-and-mock-tests-plan.md
@@ -2,9 +2,15 @@
 
 Move live Legislative Yuan API tests out of the default CI path and add offline mock tests backed by checked-in JSON samples under `tests/data`. Success means pull requests can run lint, type check, and deterministic mock tests without network dependency, while default pytest runs skip `live` tests unless `-m live` is specified.
 
+## Status
+
+Completed. CI and normal local tests use offline fixture-backed tests, while
+live tests remain available through `just test-live` and the manual live-test
+workflow.
+
 ## Context
 
-The current `CI` workflow runs `uv run pytest -v -s --cov=src --cov-report=xml tests` on `push`, `pull_request`, and `workflow_dispatch`. Before this migration, the existing API and MCP server tests called the real `https://ly.govapi.tw/v2` service during normal test runs, which made CI depend on external data shape, network availability, and API latency.
+At planning time, the `CI` workflow ran `uv run pytest -v -s --cov=src --cov-report=xml tests` on `push`, `pull_request`, and `workflow_dispatch`. Before this migration, the API and MCP server tests called the real `https://ly.govapi.tw/v2` service during normal test runs, which made CI depend on external data shape, network availability, and API latency.
 
 ## Non-Goals
 

--- a/docs/plans/2026-05-14_structured-errors-and-responses-plan.md
+++ b/docs/plans/2026-05-14_structured-errors-and-responses-plan.md
@@ -2,13 +2,18 @@
 
 Improve response and error semantics so MCP clients and tests can distinguish successful data, empty results, invalid parameters, upstream HTTP failures, timeouts, and non-JSON responses. Success means tool failures are returned in a consistent, machine-checkable shape instead of arbitrary plain strings.
 
+## Status
+
+Completed. Successful tool output remains the raw upstream payload, while
+failures now return a consistent JSON error envelope.
+
 ## Context
 
-The current API helper calls `resp.raise_for_status()` and `resp.json()` directly. Server tools catch all exceptions and return strings like `Failed to list bills, got: ...`. This keeps the MCP server from crashing, but it makes errors hard for clients, tests, and users to interpret.
+At planning time, the API helper called `resp.raise_for_status()` and `resp.json()` directly. Server tools caught all exceptions and returned strings like `Failed to list bills, got: ...`. That kept the MCP server from crashing, but it made errors hard for clients, tests, and users to interpret.
 
 ## Architecture
 
-Keep `httpx` and the current request model layer. Introduce a small local response/error helper rather than a new dependency:
+Keep `httpx` and the request model layer. Introduce a small local response/error helper rather than a new dependency:
 
 - API layer normalizes upstream HTTP and JSON failures.
 - Server layer serializes a consistent success or error envelope.

--- a/docs/plans/2026-05-14_test-contract-and-ci-verification-plan.md
+++ b/docs/plans/2026-05-14_test-contract-and-ci-verification-plan.md
@@ -2,9 +2,14 @@
 
 Make test and CI behavior match the documented offline/live split, and strengthen MCP contract tests so broken tools fail deterministically. Success means default validation does not require network access, live tests remain explicitly runnable, and tests assert JSON structure, request serialization, and error semantics instead of only checking for strings.
 
+## Status
+
+Completed. Default validation is offline, live tests remain explicit, and mock
+server tests assert parsed JSON contracts plus tool-to-request wiring.
+
 ## Context
 
-An existing completed plan, `docs/plans/2026-05-14_manual-live-and-mock-tests-plan.md`, already describes a live/mock test migration. The current repository still needs a follow-up verification pass because the research review found mismatch risks between README claims, `justfile`, pytest marker behavior, and tests that assert only `isinstance(response_text, str)`.
+An existing completed plan, `docs/plans/2026-05-14_manual-live-and-mock-tests-plan.md`, already described a live/mock test migration. At planning time, the repository still needed a follow-up verification pass because the research review found mismatch risks between README claims, `justfile`, pytest marker behavior, and tests that asserted only `isinstance(response_text, str)`.
 
 ## Non-Goals
 

--- a/tests/test_server_mock.py
+++ b/tests/test_server_mock.py
@@ -19,6 +19,94 @@ LIST_CONTRACT_CASES = [
 ]
 
 
+DETAIL_ERROR_CASES = [
+    (
+        "get_bill",
+        "GetBillRequest",
+        {"bill_no": "invalid_bill_number"},
+        f"{api.BASE_URL}/bills/invalid_bill_number",
+    ),
+    (
+        "get_law_version",
+        "GetLawVersionRequest",
+        {"law_version_id": "invalid_law_version"},
+        f"{api.BASE_URL}/law_versions/invalid_law_version",
+    ),
+]
+
+
+TOOL_RESPONSE_CASES = [
+    ("get_bill_related_bills", "GetBillRelatedBillsRequest", {"bill_no": "202110213410000", "limit": 1}),
+    ("get_bill_meets", "GetBillMeetsRequest", {"bill_no": "202110213410000", "term": 11, "limit": 1}),
+    ("get_bill_doc_html", "GetBillDocHtmlRequest", {"bill_no": "202110213410000"}),
+    ("list_committees", "ListCommitteesRequest", {"limit": 1}),
+    ("get_committee", "GetCommitteeRequest", {"comt_cd": "16"}),
+    ("get_committee_meets", "GetCommitteeMeetsRequest", {"comt_cd": "16", "term": 11, "limit": 1}),
+    ("list_gazettes", "ListGazettesRequest", {"limit": 1}),
+    ("get_gazette", "GetGazetteRequest", {"gazette_id": "1137701"}),
+    ("get_gazette_agendas", "GetGazetteAgendasRequest", {"gazette_id": "1137701", "term": 11, "limit": 1}),
+    ("list_gazette_agendas", "ListGazetteAgendasRequest", {"term": 11, "limit": 1}),
+    ("get_gazette_agenda", "GetGazetteAgendaRequest", {"gazette_agenda_id": "1137701_00001"}),
+    ("list_interpellations", "ListInterpellationsRequest", {"interpellation_member": "羅智強", "limit": 1}),
+    ("get_interpellation", "GetInterpellationRequest", {"interpellation_id": "11-1-1-1"}),
+    (
+        "get_legislator_interpellations",
+        "GetLegislatorInterpellationsRequest",
+        {"term": 11, "name": "韓國瑜", "limit": 1},
+    ),
+    ("list_ivods", "ListIvodsRequest", {"term": 11, "video_type": "Clip", "limit": 1}),
+    ("get_ivod", "GetIvodRequest", {"ivod_id": "156045"}),
+    ("get_meet_ivods", "GetMeetIvodsRequest", {"meet_id": "院會-11-2-3", "term": 11, "limit": 1}),
+    ("list_laws", "ListLawsRequest", {"limit": 1}),
+    ("get_law", "GetLawRequest", {"law_id": "09200015"}),
+    ("get_law_progress", "GetLawProgressRequest", {"law_id": "09200015"}),
+    ("get_law_bills", "GetLawBillsRequest", {"law_id": "09200015", "term": 11, "limit": 1}),
+    ("get_law_versions", "GetLawVersionsRequest", {"law_id": "09200015", "limit": 1}),
+    ("list_law_versions", "ListLawVersionsRequest", {"law_number": "90481", "limit": 1}),
+    ("get_law_version", "GetLawVersionRequest", {"law_version_id": "90481:1944-02-29-制定"}),
+    (
+        "get_law_version_contents",
+        "GetLawVersionContentsRequest",
+        {"law_version_id": "90481:1944-02-29-制定", "law_number": "90481", "limit": 1},
+    ),
+    ("list_law_contents", "ListLawContentsRequest", {"law_number": "90481", "limit": 1}),
+    ("get_law_content", "GetLawContentRequest", {"law_content_id": "90481:90481:1944-02-29-制定:0"}),
+    ("list_legislators", "ListLegislatorsRequest", {"term": 11, "limit": 1}),
+    ("get_legislator", "GetLegislatorRequest", {"term": 11, "name": "韓國瑜"}),
+    (
+        "get_legislator_propose_bills",
+        "GetLegislatorProposeBillsRequest",
+        {"term": 11, "name": "韓國瑜", "limit": 1},
+    ),
+    (
+        "get_legislator_cosign_bills",
+        "GetLegislatorCosignBillsRequest",
+        {"term": 11, "name": "韓國瑜", "limit": 1},
+    ),
+    (
+        "get_legislator_meets",
+        "GetLegislatorMeetsRequest",
+        {"term": 11, "name": "韓國瑜", "limit": 1},
+    ),
+    ("list_meets", "ListMeetsRequest", {"term": 11, "limit": 1}),
+    ("get_meet", "GetMeetRequest", {"meet_id": "院會-11-2-3"}),
+    ("get_meet_bills", "GetMeetBillsRequest", {"meet_id": "院會-11-2-3", "term": 11, "limit": 1}),
+    (
+        "get_meet_interpellations",
+        "GetMeetInterpellationsRequest",
+        {"meet_id": "院會-11-2-3", "term": 11, "limit": 1},
+    ),
+]
+
+
+OFFLINE_MOCK_TOOL_NAMES = (
+    {"get_stat", "list_bills", "get_bill"}
+    | {tool_name for tool_name, *_ in LIST_CONTRACT_CASES}
+    | {tool_name for tool_name, *_ in DETAIL_ERROR_CASES}
+    | {tool_name for tool_name, *_ in TOOL_RESPONSE_CASES}
+)
+
+
 EXPECTED_PROMPTS = {
     "latest_plenary_meeting_bills",
     "law_amendment_history",
@@ -34,6 +122,13 @@ class StubRequest:
 
     async def do(self) -> dict[str, Any]:
         return self.response
+
+
+@pytest.mark.asyncio
+async def test_registered_tools_have_offline_mock_coverage() -> None:
+    tools = await server.mcp.list_tools()
+
+    assert {tool.name for tool in tools} == OFFLINE_MOCK_TOOL_NAMES
 
 
 @pytest.mark.asyncio
@@ -140,23 +235,7 @@ async def test_get_bill_returns_fixture_json(monkeypatch: pytest.MonkeyPatch) ->
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize(
-    ("tool_name", "request_class_name", "call_kwargs", "url"),
-    [
-        (
-            "get_bill",
-            "GetBillRequest",
-            {"bill_no": "invalid_bill_number"},
-            f"{api.BASE_URL}/bills/invalid_bill_number",
-        ),
-        (
-            "get_law_version",
-            "GetLawVersionRequest",
-            {"law_version_id": "invalid_law_version"},
-            f"{api.BASE_URL}/law_versions/invalid_law_version",
-        ),
-    ],
-)
+@pytest.mark.parametrize(("tool_name", "request_class_name", "call_kwargs", "url"), DETAIL_ERROR_CASES)
 async def test_detail_tool_returns_structured_http_status_error(
     monkeypatch: pytest.MonkeyPatch,
     tool_name: str,
@@ -221,71 +300,7 @@ async def test_list_tool_returns_collection_contract(
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize(
-    ("tool_name", "request_class_name", "call_kwargs"),
-    [
-        ("get_bill_related_bills", "GetBillRelatedBillsRequest", {"bill_no": "202110213410000", "limit": 1}),
-        ("get_bill_meets", "GetBillMeetsRequest", {"bill_no": "202110213410000", "term": 11, "limit": 1}),
-        ("get_bill_doc_html", "GetBillDocHtmlRequest", {"bill_no": "202110213410000"}),
-        ("list_committees", "ListCommitteesRequest", {"limit": 1}),
-        ("get_committee", "GetCommitteeRequest", {"comt_cd": "16"}),
-        ("get_committee_meets", "GetCommitteeMeetsRequest", {"comt_cd": "16", "term": 11, "limit": 1}),
-        ("list_gazettes", "ListGazettesRequest", {"limit": 1}),
-        ("get_gazette", "GetGazetteRequest", {"gazette_id": "1137701"}),
-        ("get_gazette_agendas", "GetGazetteAgendasRequest", {"gazette_id": "1137701", "term": 11, "limit": 1}),
-        ("list_gazette_agendas", "ListGazetteAgendasRequest", {"term": 11, "limit": 1}),
-        ("get_gazette_agenda", "GetGazetteAgendaRequest", {"gazette_agenda_id": "1137701_00001"}),
-        ("list_interpellations", "ListInterpellationsRequest", {"interpellation_member": "羅智強", "limit": 1}),
-        ("get_interpellation", "GetInterpellationRequest", {"interpellation_id": "11-1-1-1"}),
-        (
-            "get_legislator_interpellations",
-            "GetLegislatorInterpellationsRequest",
-            {"term": 11, "name": "韓國瑜", "limit": 1},
-        ),
-        ("list_ivods", "ListIvodsRequest", {"term": 11, "video_type": "Clip", "limit": 1}),
-        ("get_ivod", "GetIvodRequest", {"ivod_id": "156045"}),
-        ("get_meet_ivods", "GetMeetIvodsRequest", {"meet_id": "院會-11-2-3", "term": 11, "limit": 1}),
-        ("list_laws", "ListLawsRequest", {"limit": 1}),
-        ("get_law", "GetLawRequest", {"law_id": "09200015"}),
-        ("get_law_progress", "GetLawProgressRequest", {"law_id": "09200015"}),
-        ("get_law_bills", "GetLawBillsRequest", {"law_id": "09200015", "term": 11, "limit": 1}),
-        ("get_law_versions", "GetLawVersionsRequest", {"law_id": "09200015", "limit": 1}),
-        ("list_law_versions", "ListLawVersionsRequest", {"law_number": "90481", "limit": 1}),
-        ("get_law_version", "GetLawVersionRequest", {"law_version_id": "90481:1944-02-29-制定"}),
-        (
-            "get_law_version_contents",
-            "GetLawVersionContentsRequest",
-            {"law_version_id": "90481:1944-02-29-制定", "law_number": "90481", "limit": 1},
-        ),
-        ("list_law_contents", "ListLawContentsRequest", {"law_number": "90481", "limit": 1}),
-        ("get_law_content", "GetLawContentRequest", {"law_content_id": "90481:90481:1944-02-29-制定:0"}),
-        ("list_legislators", "ListLegislatorsRequest", {"term": 11, "limit": 1}),
-        ("get_legislator", "GetLegislatorRequest", {"term": 11, "name": "韓國瑜"}),
-        (
-            "get_legislator_propose_bills",
-            "GetLegislatorProposeBillsRequest",
-            {"term": 11, "name": "韓國瑜", "limit": 1},
-        ),
-        (
-            "get_legislator_cosign_bills",
-            "GetLegislatorCosignBillsRequest",
-            {"term": 11, "name": "韓國瑜", "limit": 1},
-        ),
-        (
-            "get_legislator_meets",
-            "GetLegislatorMeetsRequest",
-            {"term": 11, "name": "韓國瑜", "limit": 1},
-        ),
-        ("list_meets", "ListMeetsRequest", {"term": 11, "limit": 1}),
-        ("get_meet", "GetMeetRequest", {"meet_id": "院會-11-2-3"}),
-        ("get_meet_bills", "GetMeetBillsRequest", {"meet_id": "院會-11-2-3", "term": 11, "limit": 1}),
-        (
-            "get_meet_interpellations",
-            "GetMeetInterpellationsRequest",
-            {"meet_id": "院會-11-2-3", "term": 11, "limit": 1},
-        ),
-    ],
-)
+@pytest.mark.parametrize(("tool_name", "request_class_name", "call_kwargs"), TOOL_RESPONSE_CASES)
 async def test_tool_returns_request_response(
     monkeypatch: pytest.MonkeyPatch,
     tool_name: str,


### PR DESCRIPTION
## Summary
- add completed status sections to the finished improvement plans
- rewrite planning-time context so completed plans no longer read like open current gaps
- add an offline server-tool coverage guard while reorganizing mock tool cases

## Verification
- rg for unchecked boxes, TODO, TBD, and stale current-gap phrases in docs README
- uv run pytest tests/test_server_mock.py -q
- just lint
- just type
- just test