### PR TITLE
Add GitHub release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,28 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v7
+        with:
+          python-version: "3.12"
+      - name: Build distributions
+        run: uv build
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.PAT_TOKEN || github.token }}
+        run: |
+          gh release create "${{ github.ref_name }}" dist/* \
+            --repo "${{ github.repository }}" \
+            --title "${{ github.ref_name }}" \
+            --generate-notes


### PR DESCRIPTION
## Summary
- add a GitHub Release workflow for v*.*.* tag pushes
- build distributions with uv and upload dist assets to the release
- prefer PAT_TOKEN for release creation, falling back to github.token

## Verification
- git diff --check --cached
- commit hooks: check yaml, end-of-file, line endings, trailing whitespace