### PR TITLE
feat(cli): add ly terminal commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,42 @@ uvx lymcp@latest
 }
 ```
 
+### 💻 Terminal CLI
+
+套件也提供 `ly` 指令，讓 agents 或 shell workflow 可以直接從 terminal 查詢立法院 API。CLI 預設輸出 pretty JSON，失敗時會輸出和 MCP tools 相同的 JSON error envelope 並回傳非 0 exit code。
+
+```bash
+ly --help
+ly stat
+ly bills list --term 11 --bill-type 法律案 --limit 5
+ly bills get 202110213410000
+ly laws versions 09200015 --limit 5
+ly meets bills 院會-11-2-3 --term 11 --limit 5
+ly legislators propose-bills 11 韓國瑜 --limit 5
+```
+
+給 agents 使用時，建議用資料領域選 command group：
+
+- `ly bills ...` 查議案、關聯議案、審議會議與議案本文 HTML。
+- `ly laws ...`、`ly law-versions ...`、`ly law-contents ...` 查法律、修法版本與法條內容。
+- `ly meets ...` 查會議、會議中的議案、質詢與 IVOD。
+- `ly legislators ...` 查立法委員、提案、連署、出席會議與質詢。
+- `ly gazettes ...`、`ly gazette-agendas ...` 查公報與公報目錄。
+- `ly committees ...`、`ly interpellations ...`、`ly ivods ...` 查委員會、質詢與網路電視資料。
+
+常用輸出選項：
+
+```bash
+# 單行 JSON，方便 pipe 給其他工具
+ly --compact bills list --term 11 --limit 1
+
+# 將成功結果寫入檔案
+ly --output bills.json bills list --term 11 --limit 20
+
+# 傳遞上游 output_fields
+ly bills list --term 11 --fields 議案編號,案由,提案日期
+```
+
 ## 💬 範例提示
 
 連上 MCP 伺服器後，可以向 LLM 提出這類問題：

--- a/docs/plans/2026-05-14_cli-support-plan.md
+++ b/docs/plans/2026-05-14_cli-support-plan.md
@@ -1,0 +1,137 @@
+## Goal
+
+讓 `lymcp` 另外提供一個以 `ly` 開頭的 Typer CLI，讓 agents 可以直接從 terminal 查詢立法院 API v2 資料，並能搭配 agent skills 穩定產生、執行、解析指令。成功條件是使用者可安裝套件後執行 `ly ...`，用一致的 command tree 查詢統計、議案、法律、會議、委員、公報、質詢與 IVOD 資料，且輸出預設為 agent-friendly JSON。
+
+## Context
+
+目前 `src/lymcp/api.py` 已有每個 endpoint 的 Pydantic request class 與 `.do()` 方法，`src/lymcp/server.py` 只是把這些 request class 包成 MCP tools。CLI 應重用 `api.py`，不要再建立第二套 HTTP client 或 query serialization。
+
+目前 `pyproject.toml` 只有 `lymcp = "lymcp.server:main"` console script。新增 CLI 時，應保留 MCP server script，另外新增 `ly = "lymcp.cli:app"` 或等價入口。
+
+## Architecture
+
+CLI 採三層結構：
+
+- `src/lymcp/cli.py`：Typer app 與 command wiring，只負責參數、輸出格式、exit code。
+- `src/lymcp/cli_runner.py` 或 `src/lymcp/cli_output.py`：共用 async 執行、JSON pretty print、錯誤轉 exit code 的小型 helper。
+- `src/lymcp/api.py`：既有 Request class 繼續作為唯一 API access layer。
+
+Command tree 以資料領域分組，保留與 MCP tools 接近的命名，讓 agent skills 可以從 MCP tool 名稱直覺映射到 CLI：
+
+```text
+ly stat
+
+ly bills list [filters]
+ly bills get BILL_NO
+ly bills related BILL_NO [--page N --limit N]
+ly bills meets BILL_NO [filters]
+ly bills doc-html BILL_NO
+
+ly committees list [filters]
+ly committees get COMT_CD
+ly committees meets COMT_CD [filters]
+
+ly gazettes list [filters]
+ly gazettes get GAZETTE_ID
+ly gazettes agendas GAZETTE_ID [filters]
+ly gazette-agendas list [filters]
+ly gazette-agendas get GAZETTE_AGENDA_ID
+
+ly interpellations list [filters]
+ly interpellations get INTERPELLATION_ID
+
+ly ivods list [filters]
+ly ivods get IVOD_ID
+
+ly laws list [filters]
+ly laws get LAW_ID
+ly laws progress LAW_ID
+ly laws bills LAW_ID [filters]
+ly laws versions LAW_ID [filters]
+ly law-versions list [filters]
+ly law-versions get LAW_VERSION_ID
+ly law-versions contents LAW_VERSION_ID [filters]
+ly law-contents list [filters]
+ly law-contents get LAW_CONTENT_ID
+
+ly legislators list [filters]
+ly legislators get TERM NAME
+ly legislators propose-bills TERM NAME [filters]
+ly legislators cosign-bills TERM NAME [filters]
+ly legislators meets TERM NAME [filters]
+ly legislators interpellations TERM NAME [filters]
+
+ly meets list [filters]
+ly meets get MEET_ID
+ly meets bills MEET_ID [filters]
+ly meets interpellations MEET_ID [filters]
+ly meets ivods MEET_ID [filters]
+```
+
+Command 設計原則：
+
+- 用 plural noun group 對應 list/get workflow，例如 `ly bills list`、`ly bills get`。
+- 子資源用自然名詞或動詞片語，例如 `related`、`meets`、`doc-html`、`versions`。
+- ID 採 positional argument，filters 採 options，方便 agents 組指令時分清必填與選填。
+- filter option 名稱沿用 Python/MCP 參數的英文 snake/kebab 語意，例如 `--bill-type`、`--proposal-date`、`--committee-code`。
+- 預設輸出 pretty JSON；全域提供 `--compact` 產生單行 JSON，`--output PATH` 寫入檔案，`--fields a,b,c` 對應 `output_fields`。
+- 錯誤輸出沿用目前 MCP 的 JSON error envelope，CLI exit code 非 0，讓 agents 能可靠判斷失敗。
+
+## Tech Stack
+
+- 新增 runtime dependency：`typer`，用 `uv add typer` 更新 `pyproject.toml` 與 `uv.lock`。
+- 使用 Typer `app = typer.Typer(...)` 建立多層 command app。
+- 使用 `asyncio.run()` 執行既有 async request `.do()`。
+- 測試使用 `typer.testing.CliRunner`，搭配既有 monkeypatch / fixture pattern。
+
+## Non-Goals
+
+- 不在第一階段做自然語言查詢或 LLM planning；CLI 只提供明確 command 與 filters。
+- 不做 table、CSV、Markdown 等人類閱讀輸出；第一版先以 JSON 作為 agent-friendly contract。
+- 不改 MCP tool 名稱或既有 MCP server 行為。
+- 不做 live API smoke 作為預設測試；live tests 仍只放在 `just test-live`。
+
+## Assumptions
+
+- `ly` 這個 console script 名稱可以被此套件占用，且比 `lymcp` 更適合 terminal 查詢。
+- Agents 會偏好穩定、可解析、完整的 JSON，而不是表格摘要。
+- CLI command coverage 第一版應對齊現有 MCP tools，而不是只做少量 high-level shortcuts。
+
+## Unknowns
+
+- 是否需要 `ly prompts ...` 或 `ly workflows ...` 這類 command 來輸出 agent skill guidance；先在 README/skill 文件中描述 CLI usage，若 agents 需要可再新增。
+- 是否要支援 `--jq` 或內建欄位投影；第一版只做 upstream `output_fields` 與 JSON output，避免引入額外 dependency 或自製查詢語法。
+
+## Plan
+
+- [ ] 新增 Typer dependency 與 console script：執行 `uv add typer`，在 `pyproject.toml` 加入 `ly = "lymcp.cli:app"`，並確認 `uv lock` 已更新；verify with `uv run ly --help` 可啟動且 `git diff -- pyproject.toml uv.lock` 只含預期 dependency/script 變更。
+- [ ] 建立 `src/lymcp/cli.py` 的 root app、全域輸出 options 與 `ly stat` command，重用 `GetStatRequest().do()` 並輸出 JSON；verify with `uv run ly stat` against a monkeypatched offline test and `uv run ly --help` showing the root command.
+- [ ] 建立 CLI 共用執行與輸出 helper，將 successful dict pretty-print 成 UTF-8 JSON，將 `LymcpApiError` 與 unexpected exceptions 轉為既有 JSON error envelope 與非零 exit code；verify with `uv run pytest -v -s tests/test_cli_mock.py -k error`.
+- [ ] 實作第一組 list/get command groups：`bills`、`laws`、`meets`、`legislators`，每個 group 至少包含 `list` 與 `get`，並涵蓋常用 filters；verify with `CliRunner` tests asserting request class kwargs and JSON stdout for fixture-backed responses.
+- [ ] 實作剩餘 command groups：`committees`、`gazettes`、`gazette-agendas`、`interpellations`、`ivods`、`law-versions`、`law-contents`，讓 CLI coverage 對齊所有 MCP tools；verify with a parametrized test comparing expected command inventory to the 39 existing tool-equivalent operations.
+- [ ] 為 agent-friendly usage 補上 README CLI 區塊，包含安裝後 `ly --help`、三到五個穩定範例、JSON output contract、錯誤 envelope、以及 MCP tool 到 CLI command 的映射規則；verify with `rg -n "ly bills list|ly laws versions|JSON" README.md`.
+- [ ] 若需要 agent skill 支援，新增或規劃 repo-local skill 文件，描述 command selection、date semantics、ID resolution workflow、以及何時改用 MCP tools；verify with skill file review or an explicit follow-up plan if repo does not yet want a skill in this PR.
+- [ ] 增加 CLI offline tests 到 `tests/test_cli_mock.py`，覆蓋 help、success JSON、error JSON、required argument failures、list filters、detail positional IDs、`--compact` 或 `--output` 行為；verify with `uv run pytest -v -s tests/test_cli_mock.py`.
+- [ ] 跑完整品質檢查，確認 CLI 變更沒有破壞 MCP server；verify with `just lint`, `just type`, and `just test`.
+
+## Risks
+
+- Command 數量接近 MCP tools，若一次手寫大量 Typer wiring 容易出現參數漏接或命名不一致；用 parametrized tests 與明確 command inventory 降低風險。
+- Typer option 預設會把 snake_case 轉成 kebab-case，需在 README 與 tests 中固定使用 `--bill-type` 這類 kebab-case，避免 agent skills 產生錯誤指令。
+- `output_fields` 是 list 參數，CLI UX 可能有 `--field A --field B` 與 `--fields A,B` 的取捨；第一版需選一種並寫入 docs/tests。
+- 使用 `ly` 作為短 command 可能與使用者環境其他 binary 撞名；若發現衝突，保留 `lymcp` server script 並可考慮額外提供 `lymcp-cli` 作為 fallback。
+
+## Rollback / Recovery
+
+- 若 Typer CLI scope 過大，可保留 `typer` dependency 與 `ly stat` 作為最小可用 CLI，把完整 39-command coverage 拆成後續 PR。
+- 若 `ly` 名稱衝突，回退 `pyproject.toml` 的 `ly` script，改用 `lymcp-cli`，不影響既有 `lymcp` MCP server script。
+- 若 CLI tests 暴露 Request class 與 MCP wrapper 命名不一致，優先修 CLI mapping，不改既有 API request 或 MCP tools。
+
+## Completion Checklist
+
+- [ ] `ly` console script 可用，並由 `uv run ly --help` 與 `pyproject.toml` 的 `[project.scripts]` 證明。
+- [ ] CLI commands 覆蓋既有 39 個 MCP tool-equivalent operations，並由 command inventory test 證明。
+- [ ] CLI 成功輸出與失敗輸出都是 agent-friendly JSON，並由 `tests/test_cli_mock.py` success/error cases 證明。
+- [ ] CLI 使用既有 `src/lymcp/api.py` request classes，且沒有新增第二套 HTTP client，並由 code review 或 targeted tests 證明。
+- [ ] README 已記錄 `ly` 安裝與使用方式、範例 commands、輸出 contract 與日期/ID 查詢注意事項，並由 README diff 證明。
+- [ ] 品質檢查 `just lint`, `just type`, and `just test` 全部通過。

--- a/docs/plans/2026-05-14_cli-support-plan.md
+++ b/docs/plans/2026-05-14_cli-support-plan.md
@@ -104,15 +104,15 @@ Command 設計原則：
 
 ## Plan
 
-- [ ] 新增 Typer dependency 與 console script：執行 `uv add typer`，在 `pyproject.toml` 加入 `ly = "lymcp.cli:app"`，並確認 `uv lock` 已更新；verify with `uv run ly --help` 可啟動且 `git diff -- pyproject.toml uv.lock` 只含預期 dependency/script 變更。
-- [ ] 建立 `src/lymcp/cli.py` 的 root app、全域輸出 options 與 `ly stat` command，重用 `GetStatRequest().do()` 並輸出 JSON；verify with `uv run ly stat` against a monkeypatched offline test and `uv run ly --help` showing the root command.
-- [ ] 建立 CLI 共用執行與輸出 helper，將 successful dict pretty-print 成 UTF-8 JSON，將 `LymcpApiError` 與 unexpected exceptions 轉為既有 JSON error envelope 與非零 exit code；verify with `uv run pytest -v -s tests/test_cli_mock.py -k error`.
-- [ ] 實作第一組 list/get command groups：`bills`、`laws`、`meets`、`legislators`，每個 group 至少包含 `list` 與 `get`，並涵蓋常用 filters；verify with `CliRunner` tests asserting request class kwargs and JSON stdout for fixture-backed responses.
-- [ ] 實作剩餘 command groups：`committees`、`gazettes`、`gazette-agendas`、`interpellations`、`ivods`、`law-versions`、`law-contents`，讓 CLI coverage 對齊所有 MCP tools；verify with a parametrized test comparing expected command inventory to the 39 existing tool-equivalent operations.
-- [ ] 為 agent-friendly usage 補上 README CLI 區塊，包含安裝後 `ly --help`、三到五個穩定範例、JSON output contract、錯誤 envelope、以及 MCP tool 到 CLI command 的映射規則；verify with `rg -n "ly bills list|ly laws versions|JSON" README.md`.
-- [ ] 若需要 agent skill 支援，新增或規劃 repo-local skill 文件，描述 command selection、date semantics、ID resolution workflow、以及何時改用 MCP tools；verify with skill file review or an explicit follow-up plan if repo does not yet want a skill in this PR.
-- [ ] 增加 CLI offline tests 到 `tests/test_cli_mock.py`，覆蓋 help、success JSON、error JSON、required argument failures、list filters、detail positional IDs、`--compact` 或 `--output` 行為；verify with `uv run pytest -v -s tests/test_cli_mock.py`.
-- [ ] 跑完整品質檢查，確認 CLI 變更沒有破壞 MCP server；verify with `just lint`, `just type`, and `just test`.
+- [x] 新增 Typer dependency 與 console script：執行 `uv add typer`，在 `pyproject.toml` 加入 `ly = "lymcp.cli:app"`，並確認 `uv.lock` 已更新；verified with `UV_CACHE_DIR=/tmp/uv-cache uv run ly --help`.
+- [x] 建立 `src/lymcp/cli.py` 的 root app、全域輸出 options 與 `ly stat` command，重用 `GetStatRequest().do()` 並輸出 JSON；verified with `tests/test_cli_mock.py::test_stat_outputs_fixture_json` and `UV_CACHE_DIR=/tmp/uv-cache uv run ly --help`.
+- [x] 建立 CLI 共用執行與輸出 helper，將 successful dict pretty-print 成 UTF-8 JSON，將 `LymcpApiError` 與 unexpected exceptions 轉為既有 JSON error envelope 與非零 exit code；verified with `tests/test_cli_mock.py::test_api_error_outputs_json_to_stderr`.
+- [x] 實作第一組 list/get command groups：`bills`、`laws`、`meets`、`legislators`，每個 group 至少包含 `list` 與 `get`，並涵蓋常用 filters；verified with `COMMAND_INVENTORY`, `CliRunner` tests, and help smoke commands.
+- [x] 實作剩餘 command groups：`committees`、`gazettes`、`gazette-agendas`、`interpellations`、`ivods`、`law-versions`、`law-contents`，讓 CLI coverage 對齊所有 MCP tools；verified with `tests/test_cli_mock.py::test_command_inventory_matches_mcp_tool_coverage`.
+- [x] 為 agent-friendly usage 補上 README CLI 區塊，包含安裝後 `ly --help`、三到五個穩定範例、JSON output contract、錯誤 envelope、以及 MCP tool 到 CLI command 的映射規則；verified with `rg -n "ly bills list|ly laws versions|JSON" README.md`.
+- [x] Not applicable: repo-local skill file was not added in this PR because this repository does not currently define a `skills/` layout. Agent-facing command selection guidance is documented in README, and a future repo-local skill can consume the stable `ly ...` command tree.
+- [x] 增加 CLI offline tests 到 `tests/test_cli_mock.py`，覆蓋 help、success JSON、error JSON、required argument failures、list filters、detail positional IDs、`--compact` 或 `--output` 行為；verified with `UV_CACHE_DIR=/tmp/uv-cache uv run pytest -v -s tests/test_cli_mock.py`.
+- [x] 跑完整品質檢查，確認 CLI 變更沒有破壞 MCP server；verified with `UV_CACHE_DIR=/tmp/uv-cache just lint`, `UV_CACHE_DIR=/tmp/uv-cache just type`, and `UV_CACHE_DIR=/tmp/uv-cache just test`.
 
 ## Risks
 
@@ -129,9 +129,9 @@ Command 設計原則：
 
 ## Completion Checklist
 
-- [ ] `ly` console script 可用，並由 `uv run ly --help` 與 `pyproject.toml` 的 `[project.scripts]` 證明。
-- [ ] CLI commands 覆蓋既有 39 個 MCP tool-equivalent operations，並由 command inventory test 證明。
-- [ ] CLI 成功輸出與失敗輸出都是 agent-friendly JSON，並由 `tests/test_cli_mock.py` success/error cases 證明。
-- [ ] CLI 使用既有 `src/lymcp/api.py` request classes，且沒有新增第二套 HTTP client，並由 code review 或 targeted tests 證明。
-- [ ] README 已記錄 `ly` 安裝與使用方式、範例 commands、輸出 contract 與日期/ID 查詢注意事項，並由 README diff 證明。
-- [ ] 品質檢查 `just lint`, `just type`, and `just test` 全部通過。
+- [x] `ly` console script 可用，並由 `UV_CACHE_DIR=/tmp/uv-cache uv run ly --help` 與 `pyproject.toml` 的 `[project.scripts]` 證明。
+- [x] CLI commands 覆蓋既有 39 個 MCP tool-equivalent operations，並由 `tests/test_cli_mock.py::test_command_inventory_matches_mcp_tool_coverage` 證明。
+- [x] CLI 成功輸出與失敗輸出都是 agent-friendly JSON，並由 `tests/test_cli_mock.py` success/error cases 證明。
+- [x] CLI 使用既有 `src/lymcp/api.py` request classes，且沒有新增第二套 HTTP client，並由 `src/lymcp/cli.py` imports and `rg -n "make_api_request|httpx|AsyncClient|requests|BASE_URL" src/lymcp/cli.py` returning no matches 證明。
+- [x] README 已記錄 `ly` 安裝與使用方式、範例 commands、輸出 contract 與日期/ID 查詢注意事項，並由 README Terminal CLI section 證明。
+- [x] 品質檢查 `UV_CACHE_DIR=/tmp/uv-cache just lint`, `UV_CACHE_DIR=/tmp/uv-cache just type`, and `UV_CACHE_DIR=/tmp/uv-cache just test` 全部通過。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,9 +9,11 @@ dependencies    = [
   "httpx>=0.28.1",
   "loguru>=0.7.3",
   "mcp[cli]>=1.27.1",
+  "typer>=0.25.1",
 ]
 
 [project.scripts]
+ly    = "lymcp.cli:app"
 lymcp = "lymcp.server:main"
 
 [dependency-groups]

--- a/src/lymcp/cli.py
+++ b/src/lymcp/cli.py
@@ -1,0 +1,1105 @@
+import asyncio
+import json
+from pathlib import Path
+from typing import Annotated
+from typing import Any
+
+import typer
+
+from lymcp import api
+
+app = typer.Typer(no_args_is_help=True, help="Query Taiwan Legislative Yuan API v2 from the terminal.")
+bills_app = typer.Typer(no_args_is_help=True, help="Query bills.")
+committees_app = typer.Typer(no_args_is_help=True, help="Query committees.")
+gazettes_app = typer.Typer(no_args_is_help=True, help="Query gazettes.")
+gazette_agendas_app = typer.Typer(no_args_is_help=True, help="Query gazette agendas.")
+interpellations_app = typer.Typer(no_args_is_help=True, help="Query interpellations.")
+ivods_app = typer.Typer(no_args_is_help=True, help="Query IVOD recordings.")
+laws_app = typer.Typer(no_args_is_help=True, help="Query laws.")
+law_versions_app = typer.Typer(no_args_is_help=True, help="Query law versions.")
+law_contents_app = typer.Typer(no_args_is_help=True, help="Query law contents.")
+legislators_app = typer.Typer(no_args_is_help=True, help="Query legislators.")
+meets_app = typer.Typer(no_args_is_help=True, help="Query meetings.")
+
+app.add_typer(bills_app, name="bills")
+app.add_typer(committees_app, name="committees")
+app.add_typer(gazettes_app, name="gazettes")
+app.add_typer(gazette_agendas_app, name="gazette-agendas")
+app.add_typer(interpellations_app, name="interpellations")
+app.add_typer(ivods_app, name="ivods")
+app.add_typer(laws_app, name="laws")
+app.add_typer(law_versions_app, name="law-versions")
+app.add_typer(law_contents_app, name="law-contents")
+app.add_typer(legislators_app, name="legislators")
+app.add_typer(meets_app, name="meets")
+
+COMMAND_INVENTORY: tuple[tuple[str, ...], ...] = (
+    ("stat",),
+    ("bills", "list"),
+    ("bills", "get"),
+    ("bills", "related"),
+    ("bills", "meets"),
+    ("bills", "doc-html"),
+    ("committees", "list"),
+    ("committees", "get"),
+    ("committees", "meets"),
+    ("gazettes", "list"),
+    ("gazettes", "get"),
+    ("gazettes", "agendas"),
+    ("gazette-agendas", "list"),
+    ("gazette-agendas", "get"),
+    ("interpellations", "list"),
+    ("interpellations", "get"),
+    ("ivods", "list"),
+    ("ivods", "get"),
+    ("laws", "list"),
+    ("laws", "get"),
+    ("laws", "progress"),
+    ("laws", "bills"),
+    ("laws", "versions"),
+    ("law-versions", "list"),
+    ("law-versions", "get"),
+    ("law-versions", "contents"),
+    ("law-contents", "list"),
+    ("law-contents", "get"),
+    ("legislators", "list"),
+    ("legislators", "get"),
+    ("legislators", "propose-bills"),
+    ("legislators", "cosign-bills"),
+    ("legislators", "meets"),
+    ("legislators", "interpellations"),
+    ("meets", "list"),
+    ("meets", "get"),
+    ("meets", "bills"),
+    ("meets", "interpellations"),
+    ("meets", "ivods"),
+)
+
+_compact_output = False
+_output_path: Path | None = None
+
+
+def _fields(value: str | None) -> list[str]:
+    if not value:
+        return []
+    return [field.strip() for field in value.split(",") if field.strip()]
+
+
+def _json_text(payload: dict[str, Any]) -> str:
+    if _compact_output:
+        return json.dumps(payload, ensure_ascii=False, separators=(",", ":"))
+    return json.dumps(payload, ensure_ascii=False, indent=2)
+
+
+def _emit(payload: dict[str, Any], *, err: bool = False) -> None:
+    text = _json_text(payload)
+    if _output_path is not None and not err:
+        _output_path.write_text(f"{text}\n", encoding="utf-8")
+        return
+    typer.echo(text, err=err)
+
+
+def _error_payload(action: str, error: Exception) -> dict[str, Any]:
+    if isinstance(error, api.LymcpApiError):
+        return {"ok": False, "error": error.to_dict()}
+    return {
+        "ok": False,
+        "error": {
+            "type": "unexpected_error",
+            "message": f"{action}: {error}",
+        },
+    }
+
+
+def _run(request: Any, action: str) -> None:
+    try:
+        _emit(asyncio.run(request.do()))
+    except Exception as e:
+        _emit(_error_payload(action, e), err=True)
+        raise typer.Exit(1) from e
+
+
+@app.callback()
+def main(
+    compact: Annotated[bool, typer.Option("--compact", help="Print compact single-line JSON.")] = False,
+    output: Annotated[
+        Path | None,
+        typer.Option("--output", "-o", help="Write successful JSON output to a file."),
+    ] = None,
+) -> None:
+    """Query Taiwan Legislative Yuan API v2."""
+    global _compact_output, _output_path
+    _compact_output = compact
+    _output_path = output
+
+
+@app.command("stat")
+def stat() -> None:
+    """Get API statistics."""
+    _run(api.GetStatRequest(), "Failed to get statistics")
+
+
+def _bill_kwargs(
+    term: int | None,
+    session: int | None,
+    bill_flow_status: str | None,
+    bill_type: str | None,
+    proposer: str | None,
+    cosigner: str | None,
+    law_number: str | None,
+    bill_status: str | None,
+    meeting_code: str | None,
+    proposal_source: str | None,
+    bill_number: str | None,
+    proposal_number: str | None,
+    reference_number: str | None,
+    article_number: str | None,
+    proposal_date: str | None,
+    page: int,
+    limit: int,
+    fields: str | None,
+) -> dict[str, Any]:
+    return {
+        "term": term,
+        "session": session,
+        "bill_flow_status": bill_flow_status,
+        "bill_type": bill_type,
+        "proposer": proposer,
+        "co_proposer": cosigner,
+        "law_number": law_number,
+        "bill_status": bill_status,
+        "meeting_code": meeting_code,
+        "proposal_source": proposal_source,
+        "bill_number": bill_number,
+        "proposal_number": proposal_number,
+        "reference_number": reference_number,
+        "article_number": article_number,
+        "proposal_date": proposal_date,
+        "page": page,
+        "limit": limit,
+        "output_fields": _fields(fields),
+    }
+
+
+def _version_kwargs(
+    law_number: str | None,
+    version_number: str | None,
+    date: str | None,
+    action: str | None,
+    main_proposer: str | None,
+    progress: str | None,
+    current_version: str | None,
+    page: int,
+    limit: int,
+    fields: str | None,
+) -> dict[str, Any]:
+    return {
+        "law_number": law_number,
+        "version_number": version_number,
+        "date": date,
+        "action": action,
+        "main_proposer": main_proposer,
+        "progress": progress,
+        "current_version": current_version,
+        "page": page,
+        "limit": limit,
+        "output_fields": _fields(fields),
+    }
+
+
+def _ivod_kwargs(
+    term: int | None,
+    session: int | None,
+    meeting_code: str | None,
+    member_name: str | None,
+    committee_code: int | None,
+    meeting_code_data: str | None,
+    date: str | None,
+    video_type: str | None,
+    page: int,
+    limit: int,
+    fields: str | None,
+) -> dict[str, Any]:
+    return {
+        "term": term,
+        "session": session,
+        "meeting_code": meeting_code,
+        "member_name": member_name,
+        "committee_code": committee_code,
+        "meeting_code_data": meeting_code_data,
+        "date": date,
+        "video_type": video_type,
+        "page": page,
+        "limit": limit,
+        "output_fields": _fields(fields),
+    }
+
+
+@bills_app.command("list")
+def list_bills(
+    term: int | None = None,
+    session: int | None = None,
+    bill_flow_status: str | None = None,
+    bill_type: str | None = None,
+    proposer: str | None = None,
+    cosigner: str | None = None,
+    law_number: str | None = None,
+    bill_status: str | None = None,
+    meeting_code: str | None = None,
+    proposal_source: str | None = None,
+    bill_number: str | None = None,
+    proposal_number: str | None = None,
+    reference_number: str | None = None,
+    article_number: str | None = None,
+    proposal_date: str | None = None,
+    proposal_unit_or_member: str | None = None,
+    page: int = 1,
+    limit: int = 20,
+    fields: str | None = typer.Option(None, "--fields", help="Comma-separated upstream output fields."),
+) -> None:
+    """List bills."""
+    kwargs = _bill_kwargs(
+        term,
+        session,
+        bill_flow_status,
+        bill_type,
+        proposer,
+        cosigner,
+        law_number,
+        bill_status,
+        meeting_code,
+        proposal_source,
+        bill_number,
+        proposal_number,
+        reference_number,
+        article_number,
+        proposal_date,
+        page,
+        limit,
+        fields,
+    )
+    kwargs["proposal_unit_or_member"] = proposal_unit_or_member
+    _run(api.ListBillRequest(**kwargs), "Failed to list bills")
+
+
+@bills_app.command("get")
+def get_bill(bill_no: str) -> None:
+    """Get bill details."""
+    _run(api.GetBillRequest(bill_no=bill_no), "Failed to get bill")
+
+
+@bills_app.command("related")
+def get_bill_related_bills(bill_no: str, page: int = 1, limit: int = 20) -> None:
+    """Get related bills."""
+    _run(api.GetBillRelatedBillsRequest(bill_no=bill_no, page=page, limit=limit), "Failed to get related bills")
+
+
+@bills_app.command("meets")
+def get_bill_meets(
+    bill_no: str,
+    term: int | None = None,
+    session: int | None = None,
+    meeting_type: str | None = None,
+    date: str | None = None,
+    page: int = 1,
+    limit: int = 20,
+) -> None:
+    """Get bill deliberation records."""
+    _run(
+        api.GetBillMeetsRequest(
+            bill_no=bill_no,
+            term=term,
+            session=session,
+            meeting_type=meeting_type,
+            date=date,
+            page=page,
+            limit=limit,
+        ),
+        "Failed to get bill meets",
+    )
+
+
+@bills_app.command("doc-html")
+def get_bill_doc_html(bill_no: str) -> None:
+    """Get bill document HTML."""
+    _run(api.GetBillDocHtmlRequest(bill_no=bill_no), "Failed to get bill document HTML")
+
+
+@committees_app.command("list")
+def list_committees(
+    committee_type: str | None = None,
+    comt_cd: str | None = None,
+    page: int = 1,
+    limit: int = 20,
+    fields: str | None = typer.Option(None, "--fields", help="Comma-separated upstream output fields."),
+) -> None:
+    """List committees."""
+    _run(
+        api.ListCommitteesRequest(
+            committee_type=committee_type,
+            comt_cd=comt_cd,
+            page=page,
+            limit=limit,
+            output_fields=_fields(fields),
+        ),
+        "Failed to list committees",
+    )
+
+
+@committees_app.command("get")
+def get_committee(comt_cd: str) -> None:
+    """Get committee details."""
+    _run(api.GetCommitteeRequest(comt_cd=comt_cd), "Failed to get committee")
+
+
+@committees_app.command("meets")
+def get_committee_meets(
+    comt_cd: str,
+    term: int | None = None,
+    meeting_code: str | None = None,
+    session: int | None = None,
+    meeting_type: str | None = None,
+    member: str | None = None,
+    date: str | None = None,
+    committee_code: str | None = None,
+    meet_id: str | None = None,
+    bill_no: str | None = None,
+    law_number: str | None = None,
+    page: int = 1,
+    limit: int = 20,
+    fields: str | None = typer.Option(None, "--fields", help="Comma-separated upstream output fields."),
+) -> None:
+    """Get committee meeting records."""
+    _run(
+        api.GetCommitteeMeetsRequest(
+            comt_cd=comt_cd,
+            term=term,
+            meeting_code=meeting_code,
+            session=session,
+            meeting_type=meeting_type,
+            member=member,
+            date=date,
+            committee_code=committee_code,
+            meet_id=meet_id,
+            bill_no=bill_no,
+            law_number=law_number,
+            page=page,
+            limit=limit,
+            output_fields=_fields(fields),
+        ),
+        "Failed to get committee meets",
+    )
+
+
+@gazettes_app.command("list")
+def list_gazettes(
+    gazette_id: str | None = None,
+    volume: int | None = None,
+    page: int = 1,
+    limit: int = 20,
+    fields: str | None = typer.Option(None, "--fields", help="Comma-separated upstream output fields."),
+) -> None:
+    """List gazettes."""
+    _run(
+        api.ListGazettesRequest(
+            gazette_id=gazette_id,
+            volume=volume,
+            page=page,
+            limit=limit,
+            output_fields=_fields(fields),
+        ),
+        "Failed to list gazettes",
+    )
+
+
+@gazettes_app.command("get")
+def get_gazette(gazette_id: str) -> None:
+    """Get gazette details."""
+    _run(api.GetGazetteRequest(gazette_id=gazette_id), "Failed to get gazette")
+
+
+@gazettes_app.command("agendas")
+def get_gazette_agendas(
+    gazette_id: str,
+    volume: int | None = None,
+    term: int | None = None,
+    meeting_date: str | None = None,
+    page: int = 1,
+    limit: int = 20,
+    fields: str | None = typer.Option(None, "--fields", help="Comma-separated upstream output fields."),
+) -> None:
+    """Get agendas from a gazette."""
+    _run(
+        api.GetGazetteAgendasRequest(
+            gazette_id=gazette_id,
+            volume=volume,
+            term=term,
+            meeting_date=meeting_date,
+            page=page,
+            limit=limit,
+            output_fields=_fields(fields),
+        ),
+        "Failed to get gazette agendas",
+    )
+
+
+@gazette_agendas_app.command("list")
+def list_gazette_agendas(
+    gazette_id: str | None = None,
+    volume: int | None = None,
+    term: int | None = None,
+    meeting_date: str | None = None,
+    page: int = 1,
+    limit: int = 20,
+    fields: str | None = typer.Option(None, "--fields", help="Comma-separated upstream output fields."),
+) -> None:
+    """List gazette agendas."""
+    _run(
+        api.ListGazetteAgendasRequest(
+            gazette_id=gazette_id,
+            volume=volume,
+            term=term,
+            meeting_date=meeting_date,
+            page=page,
+            limit=limit,
+            output_fields=_fields(fields),
+        ),
+        "Failed to list gazette agendas",
+    )
+
+
+@gazette_agendas_app.command("get")
+def get_gazette_agenda(gazette_agenda_id: str) -> None:
+    """Get gazette agenda details."""
+    _run(api.GetGazetteAgendaRequest(gazette_agenda_id=gazette_agenda_id), "Failed to get gazette agenda")
+
+
+@interpellations_app.command("list")
+def list_interpellations(
+    interpellation_member: str | None = None,
+    term: int | None = None,
+    session: int | None = None,
+    meeting_code: str | None = None,
+    page: int = 1,
+    limit: int = 20,
+    fields: str | None = typer.Option(None, "--fields", help="Comma-separated upstream output fields."),
+) -> None:
+    """List interpellations."""
+    _run(
+        api.ListInterpellationsRequest(
+            interpellation_member=interpellation_member,
+            term=term,
+            session=session,
+            meeting_code=meeting_code,
+            page=page,
+            limit=limit,
+            output_fields=_fields(fields),
+        ),
+        "Failed to list interpellations",
+    )
+
+
+@interpellations_app.command("get")
+def get_interpellation(interpellation_id: str) -> None:
+    """Get interpellation details."""
+    _run(api.GetInterpellationRequest(interpellation_id=interpellation_id), "Failed to get interpellation")
+
+
+@ivods_app.command("list")
+def list_ivods(
+    term: int | None = None,
+    session: int | None = None,
+    meeting_code: str | None = None,
+    member_name: str | None = None,
+    committee_code: int | None = None,
+    meeting_code_data: str | None = None,
+    date: str | None = None,
+    video_type: str | None = None,
+    page: int = 1,
+    limit: int = 20,
+    fields: str | None = typer.Option(None, "--fields", help="Comma-separated upstream output fields."),
+) -> None:
+    """List IVOD recordings."""
+    _run(
+        api.ListIvodsRequest(
+            **_ivod_kwargs(
+                term,
+                session,
+                meeting_code,
+                member_name,
+                committee_code,
+                meeting_code_data,
+                date,
+                video_type,
+                page,
+                limit,
+                fields,
+            )
+        ),
+        "Failed to list IVODs",
+    )
+
+
+@ivods_app.command("get")
+def get_ivod(ivod_id: str) -> None:
+    """Get IVOD recording details."""
+    _run(api.GetIvodRequest(ivod_id=ivod_id), "Failed to get IVOD")
+
+
+@laws_app.command("list")
+def list_laws(
+    law_number: str | None = None,
+    category: str | None = None,
+    parent_law_number: str | None = None,
+    law_status: str | None = None,
+    authority: str | None = None,
+    latest_version_date: str | None = None,
+    page: int = 1,
+    limit: int = 20,
+    fields: str | None = typer.Option(None, "--fields", help="Comma-separated upstream output fields."),
+) -> None:
+    """List laws."""
+    _run(
+        api.ListLawsRequest(
+            law_number=law_number,
+            category=category,
+            parent_law_number=parent_law_number,
+            law_status=law_status,
+            authority=authority,
+            latest_version_date=latest_version_date,
+            page=page,
+            limit=limit,
+            output_fields=_fields(fields),
+        ),
+        "Failed to list laws",
+    )
+
+
+@laws_app.command("get")
+def get_law(law_id: str) -> None:
+    """Get law details."""
+    _run(api.GetLawRequest(law_id=law_id), "Failed to get law")
+
+
+@laws_app.command("progress")
+def get_law_progress(law_id: str) -> None:
+    """Get undecided progress for a law."""
+    _run(api.GetLawProgressRequest(law_id=law_id), "Failed to get law progress")
+
+
+@laws_app.command("bills")
+def get_law_bills(
+    law_id: str,
+    term: int | None = None,
+    session: int | None = None,
+    bill_flow_status: str | None = None,
+    bill_type: str | None = None,
+    proposer: str | None = None,
+    cosigner: str | None = None,
+    law_number: str | None = None,
+    bill_status: str | None = None,
+    meeting_code: str | None = None,
+    proposal_source: str | None = None,
+    bill_number: str | None = None,
+    proposal_number: str | None = None,
+    reference_number: str | None = None,
+    article_number: str | None = None,
+    proposal_date: str | None = None,
+    page: int = 1,
+    limit: int = 20,
+    fields: str | None = typer.Option(None, "--fields", help="Comma-separated upstream output fields."),
+) -> None:
+    """Get bills related to a law."""
+    kwargs = _bill_kwargs(
+        term,
+        session,
+        bill_flow_status,
+        bill_type,
+        proposer,
+        cosigner,
+        law_number,
+        bill_status,
+        meeting_code,
+        proposal_source,
+        bill_number,
+        proposal_number,
+        reference_number,
+        article_number,
+        proposal_date,
+        page,
+        limit,
+        fields,
+    )
+    kwargs["law_id"] = law_id
+    _run(api.GetLawBillsRequest(**kwargs), "Failed to get law bills")
+
+
+@laws_app.command("versions")
+def get_law_versions(
+    law_id: str,
+    law_number: str | None = None,
+    version_number: str | None = None,
+    date: str | None = None,
+    action: str | None = None,
+    main_proposer: str | None = None,
+    progress: str | None = None,
+    current_version: str | None = None,
+    page: int = 1,
+    limit: int = 20,
+    fields: str | None = typer.Option(None, "--fields", help="Comma-separated upstream output fields."),
+) -> None:
+    """Get historical versions for a law."""
+    kwargs = _version_kwargs(
+        law_number, version_number, date, action, main_proposer, progress, current_version, page, limit, fields
+    )
+    kwargs["law_id"] = law_id
+    _run(api.GetLawVersionsRequest(**kwargs), "Failed to get law versions")
+
+
+@law_versions_app.command("list")
+def list_law_versions(
+    law_number: str | None = None,
+    version_number: str | None = None,
+    date: str | None = None,
+    action: str | None = None,
+    main_proposer: str | None = None,
+    progress: str | None = None,
+    current_version: str | None = None,
+    page: int = 1,
+    limit: int = 20,
+    fields: str | None = typer.Option(None, "--fields", help="Comma-separated upstream output fields."),
+) -> None:
+    """List law versions."""
+    _run(
+        api.ListLawVersionsRequest(
+            **_version_kwargs(
+                law_number, version_number, date, action, main_proposer, progress, current_version, page, limit, fields
+            )
+        ),
+        "Failed to list law versions",
+    )
+
+
+@law_versions_app.command("get")
+def get_law_version(law_version_id: str) -> None:
+    """Get law version details."""
+    _run(api.GetLawVersionRequest(law_version_id=law_version_id), "Failed to get law version")
+
+
+@law_versions_app.command("contents")
+def get_law_version_contents(
+    law_version_id: str,
+    law_number: str | None = None,
+    version_id: str | None = None,
+    order: int | None = None,
+    article_number: str | None = None,
+    current_version_status: str | None = None,
+    version_tracking: str | None = None,
+    page: int = 1,
+    limit: int = 20,
+    fields: str | None = typer.Option(None, "--fields", help="Comma-separated upstream output fields."),
+) -> None:
+    """Get law article contents in a version."""
+    _run(
+        api.GetLawVersionContentsRequest(
+            law_version_id=law_version_id,
+            law_number=law_number,
+            version_id=version_id,
+            order=order,
+            article_number=article_number,
+            current_version_status=current_version_status,
+            version_tracking=version_tracking,
+            page=page,
+            limit=limit,
+            output_fields=_fields(fields),
+        ),
+        "Failed to get law version contents",
+    )
+
+
+@law_contents_app.command("list")
+def list_law_contents(
+    law_number: str | None = None,
+    version_id: str | None = None,
+    order: int | None = None,
+    article_number: str | None = None,
+    current_version_status: str | None = None,
+    version_tracking: str | None = None,
+    page: int = 1,
+    limit: int = 20,
+    fields: str | None = typer.Option(None, "--fields", help="Comma-separated upstream output fields."),
+) -> None:
+    """List law article contents."""
+    _run(
+        api.ListLawContentsRequest(
+            law_number=law_number,
+            version_id=version_id,
+            order=order,
+            article_number=article_number,
+            current_version_status=current_version_status,
+            version_tracking=version_tracking,
+            page=page,
+            limit=limit,
+            output_fields=_fields(fields),
+        ),
+        "Failed to list law contents",
+    )
+
+
+@law_contents_app.command("get")
+def get_law_content(law_content_id: str) -> None:
+    """Get law article content details."""
+    _run(api.GetLawContentRequest(law_content_id=law_content_id), "Failed to get law content")
+
+
+@legislators_app.command("list")
+def list_legislators(
+    term: int | None = None,
+    party: str | None = None,
+    district_name: str | None = None,
+    legislator_id: int | None = None,
+    legislator_name: str | None = None,
+    page: int = 1,
+    limit: int = 20,
+    fields: str | None = typer.Option(None, "--fields", help="Comma-separated upstream output fields."),
+) -> None:
+    """List legislators."""
+    _run(
+        api.ListLegislatorsRequest(
+            term=term,
+            party=party,
+            district_name=district_name,
+            legislator_id=legislator_id,
+            legislator_name=legislator_name,
+            page=page,
+            limit=limit,
+            output_fields=_fields(fields),
+        ),
+        "Failed to list legislators",
+    )
+
+
+@legislators_app.command("get")
+def get_legislator(term: int, name: str) -> None:
+    """Get legislator details."""
+    _run(api.GetLegislatorRequest(term=term, name=name), "Failed to get legislator")
+
+
+@legislators_app.command("propose-bills")
+def get_legislator_propose_bills(
+    term: int,
+    name: str,
+    bill_term: int | None = None,
+    session: int | None = None,
+    bill_flow_status: str | None = None,
+    bill_type: str | None = None,
+    proposer: str | None = None,
+    cosigner: str | None = None,
+    law_number: str | None = None,
+    bill_status: str | None = None,
+    meeting_code: str | None = None,
+    proposal_source: str | None = None,
+    bill_number: str | None = None,
+    proposal_number: str | None = None,
+    reference_number: str | None = None,
+    article_number: str | None = None,
+    proposal_date: str | None = None,
+    page: int = 1,
+    limit: int = 20,
+    fields: str | None = typer.Option(None, "--fields", help="Comma-separated upstream output fields."),
+) -> None:
+    """Get bills proposed by a legislator."""
+    kwargs = _bill_kwargs(
+        bill_term,
+        session,
+        bill_flow_status,
+        bill_type,
+        proposer,
+        cosigner,
+        law_number,
+        bill_status,
+        meeting_code,
+        proposal_source,
+        bill_number,
+        proposal_number,
+        reference_number,
+        article_number,
+        proposal_date,
+        page,
+        limit,
+        fields,
+    )
+    kwargs["bill_term"] = kwargs.pop("term")
+    kwargs["term"] = term
+    kwargs["name"] = name
+    _run(api.GetLegislatorProposeBillsRequest(**kwargs), "Failed to get legislator proposed bills")
+
+
+@legislators_app.command("cosign-bills")
+def get_legislator_cosign_bills(
+    term: int,
+    name: str,
+    bill_term: int | None = None,
+    session: int | None = None,
+    bill_flow_status: str | None = None,
+    bill_type: str | None = None,
+    proposer: str | None = None,
+    cosigner: str | None = None,
+    law_number: str | None = None,
+    bill_status: str | None = None,
+    meeting_code: str | None = None,
+    proposal_source: str | None = None,
+    bill_number: str | None = None,
+    proposal_number: str | None = None,
+    reference_number: str | None = None,
+    article_number: str | None = None,
+    proposal_date: str | None = None,
+    page: int = 1,
+    limit: int = 20,
+    fields: str | None = typer.Option(None, "--fields", help="Comma-separated upstream output fields."),
+) -> None:
+    """Get bills co-signed by a legislator."""
+    kwargs = _bill_kwargs(
+        bill_term,
+        session,
+        bill_flow_status,
+        bill_type,
+        proposer,
+        cosigner,
+        law_number,
+        bill_status,
+        meeting_code,
+        proposal_source,
+        bill_number,
+        proposal_number,
+        reference_number,
+        article_number,
+        proposal_date,
+        page,
+        limit,
+        fields,
+    )
+    kwargs["bill_term"] = kwargs.pop("term")
+    kwargs["term"] = term
+    kwargs["name"] = name
+    _run(api.GetLegislatorCosignBillsRequest(**kwargs), "Failed to get legislator co-signed bills")
+
+
+@legislators_app.command("meets")
+def get_legislator_meets(
+    term: int,
+    name: str,
+    meet_term: int | None = None,
+    meeting_code: str | None = None,
+    session: int | None = None,
+    meeting_type: str | None = None,
+    member: str | None = None,
+    date: str | None = None,
+    committee_code: int | None = None,
+    meet_id: str | None = None,
+    bill_no_nested: str | None = None,
+    law_number_nested: str | None = None,
+    page: int = 1,
+    limit: int = 20,
+    fields: str | None = typer.Option(None, "--fields", help="Comma-separated upstream output fields."),
+) -> None:
+    """Get meetings attended by a legislator."""
+    _run(
+        api.GetLegislatorMeetsRequest(
+            term=term,
+            name=name,
+            meet_term=meet_term,
+            meeting_code=meeting_code,
+            session=session,
+            meeting_type=meeting_type,
+            member=member,
+            date=date,
+            committee_code=committee_code,
+            meet_id=meet_id,
+            bill_no_nested=bill_no_nested,
+            law_number_nested=law_number_nested,
+            page=page,
+            limit=limit,
+            output_fields=_fields(fields),
+        ),
+        "Failed to get legislator meetings",
+    )
+
+
+@legislators_app.command("interpellations")
+def get_legislator_interpellations(
+    term: int,
+    name: str,
+    interpellation_member: str | None = None,
+    term_query: int | None = None,
+    session: int | None = None,
+    meeting_code: str | None = None,
+    page: int = 1,
+    limit: int = 20,
+    fields: str | None = typer.Option(None, "--fields", help="Comma-separated upstream output fields."),
+) -> None:
+    """Get interpellations by a legislator."""
+    _run(
+        api.GetLegislatorInterpellationsRequest(
+            term=term,
+            name=name,
+            interpellation_member=interpellation_member,
+            term_query=term_query,
+            session=session,
+            meeting_code=meeting_code,
+            page=page,
+            limit=limit,
+            output_fields=_fields(fields),
+        ),
+        "Failed to get legislator interpellations",
+    )
+
+
+@meets_app.command("list")
+def list_meets(
+    term: int | None = None,
+    meeting_code: str | None = None,
+    session: int | None = None,
+    meeting_type: str | None = None,
+    meeting_attendee: str | None = None,
+    date: str | None = None,
+    committee_code: int | None = None,
+    meeting_id: str | None = None,
+    meeting_bills_bill_no: str | None = None,
+    meeting_bills_law_no: str | None = None,
+    page: int = 1,
+    limit: int = 20,
+    fields: str | None = typer.Option(None, "--fields", help="Comma-separated upstream output fields."),
+) -> None:
+    """List meetings."""
+    _run(
+        api.ListMeetsRequest(
+            term=term,
+            meeting_code=meeting_code,
+            session=session,
+            meeting_type=meeting_type,
+            meeting_attendee=meeting_attendee,
+            date=date,
+            committee_code=committee_code,
+            meeting_id=meeting_id,
+            meeting_bills_bill_no=meeting_bills_bill_no,
+            meeting_bills_law_no=meeting_bills_law_no,
+            page=page,
+            limit=limit,
+            output_fields=_fields(fields),
+        ),
+        "Failed to list meetings",
+    )
+
+
+@meets_app.command("get")
+def get_meet(meet_id: str) -> None:
+    """Get meeting details."""
+    _run(api.GetMeetRequest(meet_id=meet_id), "Failed to get meeting")
+
+
+@meets_app.command("bills")
+def get_meet_bills(
+    meet_id: str,
+    term: int | None = None,
+    session: int | None = None,
+    bill_flow_status: str | None = None,
+    bill_type: str | None = None,
+    proposer: str | None = None,
+    cosigner: str | None = None,
+    law_number: str | None = None,
+    bill_status: str | None = None,
+    meeting_code: str | None = None,
+    proposal_source: str | None = None,
+    bill_number: str | None = None,
+    proposal_number: str | None = None,
+    reference_number: str | None = None,
+    article_number: str | None = None,
+    proposal_date: str | None = None,
+    page: int = 1,
+    limit: int = 20,
+    fields: str | None = typer.Option(None, "--fields", help="Comma-separated upstream output fields."),
+) -> None:
+    """Get bills discussed in a meeting."""
+    kwargs = _bill_kwargs(
+        term,
+        session,
+        bill_flow_status,
+        bill_type,
+        proposer,
+        cosigner,
+        law_number,
+        bill_status,
+        meeting_code,
+        proposal_source,
+        bill_number,
+        proposal_number,
+        reference_number,
+        article_number,
+        proposal_date,
+        page,
+        limit,
+        fields,
+    )
+    kwargs["meet_id"] = meet_id
+    _run(api.GetMeetBillsRequest(**kwargs), "Failed to get meeting bills")
+
+
+@meets_app.command("interpellations")
+def get_meet_interpellations(
+    meet_id: str,
+    interpellation_member: str | None = None,
+    term: int | None = None,
+    session: int | None = None,
+    meeting_code: str | None = None,
+    page: int = 1,
+    limit: int = 20,
+    fields: str | None = typer.Option(None, "--fields", help="Comma-separated upstream output fields."),
+) -> None:
+    """Get interpellations in a meeting."""
+    _run(
+        api.GetMeetInterpellationsRequest(
+            meet_id=meet_id,
+            interpellation_member=interpellation_member,
+            term=term,
+            session=session,
+            meeting_code=meeting_code,
+            page=page,
+            limit=limit,
+            output_fields=_fields(fields),
+        ),
+        "Failed to get meeting interpellations",
+    )
+
+
+@meets_app.command("ivods")
+def get_meet_ivods(
+    meet_id: str,
+    term: int | None = None,
+    session: int | None = None,
+    meeting_code: str | None = None,
+    member_name: str | None = None,
+    committee_code: int | None = None,
+    meeting_code_data: str | None = None,
+    date: str | None = None,
+    video_type: str | None = None,
+    page: int = 1,
+    limit: int = 20,
+    fields: str | None = typer.Option(None, "--fields", help="Comma-separated upstream output fields."),
+) -> None:
+    """Get IVOD recordings for a meeting."""
+    kwargs = _ivod_kwargs(
+        term,
+        session,
+        meeting_code,
+        member_name,
+        committee_code,
+        meeting_code_data,
+        date,
+        video_type,
+        page,
+        limit,
+        fields,
+    )
+    kwargs["meet_id"] = meet_id
+    _run(api.GetMeetIvodsRequest(**kwargs), "Failed to get meeting IVODs")

--- a/tests/test_cli_mock.py
+++ b/tests/test_cli_mock.py
@@ -1,0 +1,162 @@
+import json
+from pathlib import Path
+from typing import Any
+
+from typer.testing import CliRunner
+
+from lymcp import api
+from lymcp import cli
+from tests.fixtures import load_json_fixture
+
+runner = CliRunner()
+
+
+class StubRequest:
+    def __init__(self, response: dict[str, Any]) -> None:
+        self.response = response
+
+    async def do(self) -> dict[str, Any]:
+        return self.response
+
+
+def test_root_help_lists_agent_friendly_command_groups() -> None:
+    result = runner.invoke(cli.app, ["--help"])
+
+    assert result.exit_code == 0
+    assert "bills" in result.stdout
+    assert "laws" in result.stdout
+    assert "meets" in result.stdout
+    assert "legislators" in result.stdout
+
+
+def test_command_inventory_matches_mcp_tool_coverage() -> None:
+    assert len(cli.COMMAND_INVENTORY) == 39
+    assert ("stat",) in cli.COMMAND_INVENTORY
+    assert ("bills", "list") in cli.COMMAND_INVENTORY
+    assert ("law-versions", "contents") in cli.COMMAND_INVENTORY
+    assert ("meets", "ivods") in cli.COMMAND_INVENTORY
+
+
+def test_stat_outputs_fixture_json(monkeypatch: Any) -> None:
+    expected_response = load_json_fixture("stat.json")
+
+    monkeypatch.setattr(cli.api, "GetStatRequest", lambda: StubRequest(expected_response))
+
+    result = runner.invoke(cli.app, ["stat"])
+
+    assert result.exit_code == 0
+    assert json.loads(result.stdout) == expected_response
+
+
+def test_list_bills_passes_filters_and_fields(monkeypatch: Any) -> None:
+    expected_response = load_json_fixture("bills_list.json")
+    calls: list[dict[str, Any]] = []
+
+    class StubListBillRequest(StubRequest):
+        def __init__(self, **kwargs: Any) -> None:
+            calls.append(kwargs)
+            super().__init__(expected_response)
+
+    monkeypatch.setattr(cli.api, "ListBillRequest", StubListBillRequest)
+
+    result = runner.invoke(
+        cli.app,
+        [
+            "bills",
+            "list",
+            "--term",
+            "11",
+            "--bill-type",
+            "法律案",
+            "--proposal-unit-or-member",
+            "王世堅",
+            "--fields",
+            "議案編號,案由",
+            "--limit",
+            "1",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert json.loads(result.stdout) == expected_response
+    assert calls == [
+        {
+            "term": 11,
+            "session": None,
+            "bill_flow_status": None,
+            "bill_type": "法律案",
+            "proposer": None,
+            "co_proposer": None,
+            "law_number": None,
+            "bill_status": None,
+            "meeting_code": None,
+            "proposal_source": None,
+            "bill_number": None,
+            "proposal_number": None,
+            "reference_number": None,
+            "article_number": None,
+            "proposal_date": None,
+            "page": 1,
+            "limit": 1,
+            "output_fields": ["議案編號", "案由"],
+            "proposal_unit_or_member": "王世堅",
+        }
+    ]
+
+
+def test_get_bill_outputs_compact_json(monkeypatch: Any) -> None:
+    expected_response = load_json_fixture("bill_detail.json")
+
+    def stub_get_bill_request(**kwargs: Any) -> StubRequest:
+        return StubRequest({"kwargs": kwargs, **expected_response})
+
+    monkeypatch.setattr(cli.api, "GetBillRequest", stub_get_bill_request)
+
+    result = runner.invoke(cli.app, ["--compact", "bills", "get", "202110213410000"])
+
+    assert result.exit_code == 0
+    assert "\n" not in result.stdout.strip()
+    assert json.loads(result.stdout)["kwargs"] == {"bill_no": "202110213410000"}
+
+
+def test_output_writes_successful_json_to_file(monkeypatch: Any, tmp_path: Path) -> None:
+    output_path = tmp_path / "stat.json"
+    expected_response = load_json_fixture("stat.json")
+
+    monkeypatch.setattr(cli.api, "GetStatRequest", lambda: StubRequest(expected_response))
+
+    result = runner.invoke(cli.app, ["--output", str(output_path), "stat"])
+
+    assert result.exit_code == 0
+    assert result.stdout == ""
+    assert json.loads(output_path.read_text(encoding="utf-8")) == expected_response
+
+
+def test_api_error_outputs_json_to_stderr(monkeypatch: Any) -> None:
+    class StubErrorRequest:
+        async def do(self) -> dict[str, Any]:
+            raise api.LymcpApiError(
+                "http_status",
+                "Upstream API returned HTTP 404",
+                url=f"{api.BASE_URL}/bills/invalid",
+                status_code=404,
+                response_excerpt="not found",
+            )
+
+    monkeypatch.setattr(cli.api, "GetBillRequest", lambda **kwargs: StubErrorRequest())
+
+    result = runner.invoke(cli.app, ["bills", "get", "invalid"])
+
+    assert result.exit_code == 1
+    assert result.stdout == ""
+    payload = json.loads(result.stderr)
+    assert payload["ok"] is False
+    assert payload["error"]["type"] == "http_status"
+    assert payload["error"]["status_code"] == 404
+
+
+def test_required_argument_failure_exits_before_api_call() -> None:
+    result = runner.invoke(cli.app, ["bills", "get"])
+
+    assert result.exit_code != 0
+    assert "Missing argument" in result.stderr

--- a/uv.lock
+++ b/uv.lock
@@ -417,6 +417,7 @@ dependencies = [
     { name = "httpx" },
     { name = "loguru" },
     { name = "mcp", extra = ["cli"] },
+    { name = "typer" },
 ]
 
 [package.dev-dependencies]
@@ -433,6 +434,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "loguru", specifier = ">=0.7.3" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.27.1" },
+    { name = "typer", specifier = ">=0.25.1" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
## Summary
- Add a Typer-powered `ly` console script for terminal queries against the existing lymcp API request layer
- Cover 39 tool-equivalent CLI operations across bills, laws, meetings, legislators, gazettes, committees, interpellations, and IVODs
- Add agent-oriented README CLI usage plus an implementation plan document
- Add offline CLI tests for help output, command inventory, filter mapping, compact/output modes, and JSON error envelopes

## Verification
- `UV_CACHE_DIR=/tmp/uv-cache just lint`
- `UV_CACHE_DIR=/tmp/uv-cache just type`
- `UV_CACHE_DIR=/tmp/uv-cache just test`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ly --help`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ly bills list --help`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ly meets ivods --help`
