### PR TITLE
fix(server): migrate to MCP SDK 2.0

### DIFF
--- a/src/lymcp/server.py
+++ b/src/lymcp/server.py
@@ -2,7 +2,7 @@ import json
 from typing import Annotated
 
 from loguru import logger
-from mcp.server.fastmcp import FastMCP
+from mcp.server import MCPServer
 from pydantic import Field
 
 from lymcp.api import GetBillDocHtmlRequest
@@ -47,7 +47,7 @@ from lymcp.api import ListMeetsRequest
 from lymcp.api import LymcpApiError
 
 # https://github.com/jlowin/fastmcp/issues/81#issuecomment-2714245145
-mcp = FastMCP("立法院 API v2 MCP Server", log_level="ERROR")
+mcp = MCPServer("立法院 API v2 MCP Server", log_level="ERROR")
 
 
 def _serialize_tool_error(action: str, error: Exception) -> str:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -509,7 +509,7 @@ async def test_list_law_contents(server_params: StdioServerParameters) -> None:
             },
         )
 
-        assert result.isError is False
+        assert result.is_error is False
         assert len(result.content) == 1
         assert isinstance(result.content[0], TextContent)
 
@@ -535,7 +535,7 @@ async def test_list_law_contents_with_filters(server_params: StdioServerParamete
             },
         )
 
-        assert result.isError is False
+        assert result.is_error is False
         assert len(result.content) == 1
         assert isinstance(result.content[0], TextContent)
 
@@ -558,7 +558,7 @@ async def test_get_law_content(server_params: StdioServerParameters) -> None:
             },
         )
 
-        assert list_result.isError is False
+        assert list_result.is_error is False
 
         # We can also test with a known format, based on the swagger spec example
         result = await session.call_tool(
@@ -585,7 +585,7 @@ async def test_list_legislators(server_params: StdioServerParameters) -> None:
         # Test basic legislators listing
         result = await session.call_tool("list_legislators", {"page": 1, "limit": 5})
 
-        assert result.isError is False
+        assert result.is_error is False
         assert len(result.content) == 1
         assert isinstance(result.content[0], TextContent)
 
@@ -611,7 +611,7 @@ async def test_list_legislators_with_filters(server_params: StdioServerParameter
             },
         )
 
-        assert result.isError is False
+        assert result.is_error is False
         assert len(result.content) == 1
         assert isinstance(result.content[0], TextContent)
 

--- a/tests/test_server_mock.py
+++ b/tests/test_server_mock.py
@@ -149,6 +149,8 @@ async def test_discovery_resources_are_registered_and_readable() -> None:
 
     query_semantics = list(await server.mcp.read_resource("lymcp://query-semantics"))
     workflow_reference = list(await server.mcp.read_resource("lymcp://workflow-reference"))
+    assert not isinstance(query_semantics[0], tuple)
+    assert not isinstance(workflow_reference[0], tuple)
     query_semantics_text = query_semantics[0].content
     workflow_reference_text = workflow_reference[0].content
 


### PR DESCRIPTION
## Summary

- migrate the server from the removed `FastMCP` API to MCP SDK 2.0's `MCPServer`
- update live test assertions for the MCP 2.0 `CallToolResult.is_error` field
- narrow MCP 2.0 resource result unions in offline tests

## Why

The project dependency was upgraded to `mcp==2.0.0`, but the server still imported `mcp.server.fastmcp.FastMCP`. MCP SDK 2.0 removed that module and renamed the high-level server class, causing `uv run lymcp` and Codex MCP startup to fail during import.

After this change, the server loads under MCP SDK 2.0 and completes a stdio client handshake while preserving the existing tools, resources, and prompts.

## Verification

- `just lint`
- `just type`
- `just test` (100 passed, 84 live tests skipped)
- `uv run pytest -m live tests/test_server.py::test_list_tools -q` (1 passed)
