### PR TITLE
chore(registry): add MCP server metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # 🏛️ ly-mcp
 
+<!-- mcp-name: io.github.narumiruna/ly-mcp -->
+
 [![PyPI version](https://img.shields.io/pypi/v/lymcp)](https://pypi.org/project/lymcp/)
 [![Python](https://img.shields.io/pypi/pyversions/lymcp)](https://pypi.org/project/lymcp/)
 [![CI](https://github.com/narumiruna/ly-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/narumiruna/ly-mcp/actions/workflows/ci.yml)

--- a/server.json
+++ b/server.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.narumiruna/ly-mcp",
+  "title": "Legislative Yuan",
+  "description": "Model Context Protocol server for Taiwan Legislative Yuan API v2.",
+  "websiteUrl": "https://github.com/narumiruna/ly-mcp",
+  "repository": {
+    "url": "https://github.com/narumiruna/ly-mcp",
+    "source": "github"
+  },
+  "version": "0.6.1",
+  "packages": [
+    {
+      "registryType": "pypi",
+      "registryBaseUrl": "https://pypi.org",
+      "identifier": "lymcp",
+      "version": "0.6.1",
+      "runtimeHint": "uvx",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Add MCP Registry server.json metadata for the PyPI package.
- Add the PyPI ownership marker to README.md.

## Verification
- mcp-publisher validate